### PR TITLE
Update external helpers doc with global injection

### DIFF
--- a/docs/usage/external-helpers.md
+++ b/docs/usage/external-helpers.md
@@ -39,3 +39,11 @@ require("babel").buildExternalHelpers();
 ```
 
 or from an npm release in `external-helpers.js` from the babel directory.
+
+### Injecting the external helpers
+
+```js
+require("babel/external-helpers");
+```
+
+This injects the external helpers into `global`.

--- a/docs/usage/external-helpers.md
+++ b/docs/usage/external-helpers.md
@@ -47,3 +47,9 @@ require("babel/external-helpers");
 ```
 
 This injects the external helpers into `global`.
+
+```html
+<script type="application/javascript" src="your-path-to/babel/external-helpers.js"></script>
+```
+
+In a browser environment you can use a `<script>` tag to inject the `babelHelpers` into the `window` object.

--- a/docs/usage/external-helpers.md
+++ b/docs/usage/external-helpers.md
@@ -42,11 +42,16 @@ or from an npm release in `external-helpers.js` from the babel directory.
 
 ### Injecting the external helpers
 
+
+#### Node
+
 ```js
 require("babel/external-helpers");
 ```
 
 This injects the external helpers into `global`.
+
+#### Browser
 
 ```html
 <script type="application/javascript" src="your-path-to/babel/external-helpers.js"></script>


### PR DESCRIPTION
This adds documentation for injecting the `babelHelpers` into window and global.