### PR TITLE
fix "JSX and React" example

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@ layout: default
     <div class="col-md-5">
 <div class="highlight"><pre><code class="language-javascript" data-lang="javascript"><span class="kr">export</span> <span class="k">default</span> <span class="nx">React</span><span class="p">.</span><span class="nx">createClass</span><span class="p">({</span>
   <span class="nx">getInitialState</span><span class="p">()</span> <span class="p">{</span>
-    <span class="k">return</span> <span class="p">{</span> <span class="nx">num</span><span class="o">:</span> <span class="k">this</span><span class="p">.</span><span class="nx">getRandomNumber</span><span class="p">();</span> <span class="p">};</span>
+    <span class="k">return</span> <span class="p">{</span> <span class="nx">num</span><span class="o">:</span> <span class="k">this</span><span class="p">.</span><span class="nx">getRandomNumber</span><span class="p">()</span> <span class="p">};</span>
   <span class="p">},</span>
 
   <span class="nx">getRandomNumber</span><span class="p">()</span><span class="o">:</span> <span class="nx">number</span> <span class="p">{</span>
@@ -83,7 +83,7 @@ layout: default
   <span class="nx">render</span><span class="p">()</span><span class="o">:</span> <span class="nx">any</span> <span class="p">{</span>
     <span class="k">return</span> <span class="nx">&lt;div&gt;</span>
       <span class="s2">Your dice roll:</span>
-      <span class="p">{</span><span class="k">this</span><span class="p">.</span><span class="nx">state</span><span class="p">.</span><span class="nx">number</span><span class="p">}</span>
+      <span class="p">{</span><span class="k">this</span><span class="p">.</span><span class="nx">state</span><span class="p">.</span><span class="nx">num</span><span class="p">}</span>
     <span class="nx">&lt;/div&gt;;</span>
   <span class="p">}</span>
 <span class="p">});</span></code></pre></div>


### PR DESCRIPTION
![babel the transpiler for writing next generation javascript 2015-02-16 11-55-24](https://cloud.githubusercontent.com/assets/19714/6206687/ba9ec220-b5d2-11e4-97ee-104392feef4f.png)

Currently, JSX and React example doesn't work.

https://babeljs.io/repl/#?experimental=true&playground=true&evaluate=true&loose=false&spec=false&code=%0A%0Aexport%20default%20React.createClass%28{%0A%20%20getInitialState%28%29%20{%0A%20%20%20%20return%20{%20num%3A%20this.getRandomNumber%28%29%3B%20}%3B%0A%20%20}%2C%0A%0A%20%20getRandomNumber%28%29%3A%20number%20{%0A%20%20%20%20return%20Math.ceil%28Math.random%28%29%20*%206%29%3B%0A%20%20}%2C%0A%0A%20%20render%28%29%3A%20any%20{%0A%20%20%20%20return%20%3Cdiv%3E%0A%20%20%20%20%20%20Your%20dice%20roll%3A%0A%20%20%20%20%20%20{this.state.number}%0A%20%20%20%20%3C%2Fdiv%3E%3B%0A%20%20}%0A}%29%3B%0A%0A

This pull request fix this:

https://babeljs.io/repl/#?experimental=true&playground=true&evaluate=true&loose=false&spec=false&code=%0A%0Aexport%20default%20React.createClass%28{%0A%20%20getInitialState%28%29%20{%0A%20%20%20%20return%20{%20num%3A%20this.getRandomNumber%28%29%20}%3B%0A%20%20}%2C%0A%0A%20%20getRandomNumber%28%29%3A%20number%20{%0A%20%20%20%20return%20Math.ceil%28Math.random%28%29%20*%206%29%3B%0A%20%20}%2C%0A%0A%20%20render%28%29%3A%20any%20{%0A%20%20%20%20return%20%3Cdiv%3E%0A%20%20%20%20%20%20Your%20dice%20roll%3A%0A%20%20%20%20%20%20{this.state.num}%0A%20%20%20%20%3C%2Fdiv%3E%3B%0A%20%20}%0A}%29%3B%0A%0A