### PR TITLE
Fix link on Modules page

### DIFF
--- a/docs/usage/modules.md
+++ b/docs/usage/modules.md
@@ -6,7 +6,7 @@ permalink: /docs/usage/modules/
 redirect_from: /modules.html
 ---
 
-See [FAQ - What is a module formatter?](/docs/faq#what-is-a-transformer-)
+See [FAQ - What is a module formatter?](/docs/faq#what-is-a-module-formatter-)
 for module formatter terminology.
 
 <p class="lead">


### PR DESCRIPTION
Was linking to the wrong section heading.