### PR TITLE
Common.js => CommonJS

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,7 +241,7 @@ layout: default
       <p>
         Babel and Browserify get along wonderfully with the
         <a href="{{ site.baseurl }}/docs/using-babel/#browserify">official babelify transform</a> babel
-        transforms the module syntax to browserify-compatible Common.js modules
+        transforms the module syntax to browserify-compatible CommonJS modules
         by default.
       </p>
     </div>


### PR DESCRIPTION
AFAIK, it's "CommonJS", not "Common.js", per [their wiki](http://wiki.commonjs.org/wiki/CommonJS).