### PR TITLE
Docs: added spaces around `==` operator

### DIFF
--- a/docs/learn-es6.md
+++ b/docs/learn-es6.md
@@ -366,7 +366,7 @@ building global apps in JavaScript.
 "𠮷".match(/./u)[0].length == 2
 
 // new form
-"\u{20BB7}"=="𠮷" == "\uD842\uDFB7"
+"\u{20BB7}" == "𠮷" == "\uD842\uDFB7"
 
 // new String ops
 "𠮷".codePointAt(0) == 0x20BB7


### PR DESCRIPTION
For consistency and readability.