### PR TITLE
fix the result of `utility.inlineExpressions`

### DIFF
--- a/docs/usage/transformers.md
+++ b/docs/usage/transformers.md
@@ -219,7 +219,7 @@ var foo = 5 * 5;
 becomes
 
 ```javascript
-var foo = 10;
+var foo = 25;
 ```
 
 ### `utility.removeConsole`


### PR DESCRIPTION
![transformers babel 2015-03-02 16-04-25](https://cloud.githubusercontent.com/assets/19714/6436595/d31ec45c-c0f5-11e4-94b2-39be13e2e30e.png)

- http://babeljs.io/docs/usage/transformers/#utility-inline-expressions

This pull request fixes the result of `utility.inlineExpressions`.

```
$ babel -V
4.6.4
$ cat inline.js
var foo = 5 * 5;
$ babel --optional utility.inlineExpressions inline.js
"use strict";

var foo = 25;
```