### PR TITLE
add docs for double dash and new babel-external-helpers options

### DIFF
--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -110,6 +110,12 @@ $ babel-node test
 $ babel-node [options] [ -e script | script.js ] [arguments]
 ```
 
+When arguments for user script have names conflicting with node options, double dash placed before script name can be used to resolve ambiguities
+
+```sh
+$ babel-node --debug --experimental -- script.js --debug --experimental
+```
+
 ### Options
 
 | Option                   | Default              | Description                     |

--- a/docs/usage/external-helpers.md
+++ b/docs/usage/external-helpers.md
@@ -28,7 +28,7 @@ babel.transform("code", { externalHelpers: true });
 ### Getting the external helpers
 
 ```sh
-$ babel-external-helpers
+$ babel-external-helpers [options]
 ```
 
 or
@@ -38,6 +38,27 @@ require("babel").buildExternalHelpers();
 ```
 
 or from an npm release in `external-helpers.js` from the babel directory.
+
+#### Options
+
+| Option                     | Default              | Description                                 |
+| -------------------------- | -------------------- | ------------------------------------------- |
+| `-t, --output-type [type]` | `global`             | Set output format: `global`, `umd` or `var` |
+| `-l, --whitelist`          |                      | Whitelist of helpers to ONLY include        |
+
+### Output formats
+
+#### global
+
+`global` output format sets helpers as global variable by adding `babelHeleprs` to `global` or `this`.
+
+#### umd
+
+`umd` output format wraps helpers in UMD compatible with browsers, CommonJS and AMD.
+
+#### var
+
+`var` outputs variable `babelHelpers` (`var babelHelpers = {}`) and helpers are assigned to it. This output format is suitable for additional processing.
 
 ### Injecting the external helpers
 


### PR DESCRIPTION
Formats section was more detailed but I have decided to shorten it to minimum since everybody can simply type it into console and check the output. Sorry that it took so long.