### PR TITLE
Move script files to end of body. Closes #19

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -37,7 +37,4 @@
   <meta name="twitter:image:src" content="https://babeljs.io/images/share-image.png">
   <meta name="twitter:url" content="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
 
-  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/lodash.js/2.4.1/lodash.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.1/js/bootstrap.min.js"></script>
 </head>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,0 +1,23 @@
+{% if page.layout_external_scripts %}
+  {% for script_path in page.layout_external_scripts %}
+  <script src="{{ script_path }}"></script>
+  {% endfor %}
+{% endif %}
+
+{% if page.page_external_scripts %}
+  {% for script_path in page.page_external_scripts %}
+  <script src="{{ script_path }}"></script>
+  {% endfor %}
+{% endif %}
+
+{% if page.layout_scripts %}
+  {% for script_path in page.layout_scripts %}
+  <script src="{{ script_path | prepend: site.baseurl }}?t={{ site.time | date_to_xmlschema }}"></script>
+  {% endfor %}
+{% endif %}
+
+{% if page.page_scripts %}
+  {% for script_path in page.page_scripts %}
+  <script src="{{ script_path | prepend: site.baseurl }}?t={{ site.time | date_to_xmlschema }}"></script>
+  {% endfor %}
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,3 +1,9 @@
+---
+layout_external_scripts:
+ - //cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js
+ - //cdnjs.cloudflare.com/ajax/libs/lodash.js/2.4.1/lodash.min.js
+ - //cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.1/js/bootstrap.min.js
+---
 <!DOCTYPE html>
 <html lang="en" {% if page.fullscreen %}class="babel-fullscreen"{% endif %}>
 
@@ -10,6 +16,8 @@
     {{ content }}
 
     {% include footer.html %}
+
+    {% include scripts.html %}
 
   </body>
 

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -1,5 +1,7 @@
 ---
 layout: page
+layout_scripts:
+ - /scripts/docs.js
 ---
 
 <div class="container">
@@ -15,5 +17,3 @@ layout: page
     </div>
   </div>
 </div>
-
-<script src="{{ "/scripts/docs.js" | prepend: site.baseurl }}?t={{ site.time | date_to_xmlschema }}"></script>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,5 +1,7 @@
 ---
 layout: default
+layout_scripts:
+ - /scripts/social.js
 ---
 
 <div class="docs-header">
@@ -32,38 +34,6 @@ layout: default
 
       <div id="disqus_thread"></div>
 
-      <script type="text/javascript">
-      (function(d, s, id) {
-        var js, fjs = d.getElementsByTagName(s)[0];
-        if (d.getElementById(id)) return;
-        js = d.createElement(s); js.id = id;
-        js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.0";
-        fjs.parentNode.insertBefore(js, fjs);
-      }(document, 'script', 'facebook-jssdk'));
-      </script>
-
-      <script type="text/javascript">
-      window.twttr = (function(d, s, id) {
-        var t, js, fjs = d.getElementsByTagName(s)[0];
-        if (d.getElementById(id)) return;
-        js = d.createElement(s); js.id = id;
-        js.src="https://platform.twitter.com/widgets.js";
-        fjs.parentNode.insertBefore(js, fjs);
-        return window.twttr || (t = { _e: [], ready: function(f) { t._e.push(f) } })
-      }(document,"script","twitter-wjs"));
-      </script>
-
-      <script type="text/javascript">
-          /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
-          var disqus_shortname = '6to5'; // required: replace example with your forum shortname
-
-          /* * * DON'T EDIT BELOW THIS LINE * * */
-          (function() {
-              var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-              dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
-              (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-          })();
-      </script>
       <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
 
     </div>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,9 @@
 ---
 layout: default
+page_external_scripts:
+ - //cdn.rawgit.com/thejameskyle/slick/lazy-load-responsive-2/slick/slick.min.js
+page_scripts:
+ - /scripts/index.js
 ---
 
 <div class="jumbotron text-center">
@@ -283,36 +287,4 @@ layout: default
   </div>
 
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.4.1/slick.css">
-  <script src="//cdn.rawgit.com/thejameskyle/slick/lazy-load-responsive-2/slick/slick.min.js"></script>
-  <script>
-    $('.babel-slider').slick({
-      lazyLoad: 'ondemand',
-      arrows: false,
-      infinite: true,
-      speed: 500,
-      autoplay: true,
-      autoplaySpeed: 4000,
-      slidesToShow: 3,
-      slidesToScroll: 3,
-      responsive: [{
-        breakpoint: 1200,
-        settings: {
-          slidesToShow: 3,
-          slidesToScroll: 3
-        }
-      }, {
-        breakpoint: 992,
-        settings: {
-          slidesToShow: 2,
-          slidesToScroll: 2
-        }
-      }, {
-        breakpoint: 768,
-        settings: {
-          slidesToShow: 1,
-          slidesToScroll: 1
-        }
-      }]
-    });
-  </script>
 </div>

--- a/repl.html
+++ b/repl.html
@@ -3,6 +3,11 @@ layout: default
 permalink: /repl/
 fullscreen: true
 redirect_from: "/repl.html"
+page_external_scripts:
+ - //cdnjs.cloudflare.com/ajax/libs/ace/1.1.3/ace.js
+page_scripts:
+ - /scripts/babel.js 
+ - /scripts/repl.js
 ---
 
 <div class="babel-repl">
@@ -83,7 +88,4 @@ redirect_from: "/repl.html"
   <div class="babel-repl-reporter babel-repl-errors"></div>
   <div class="babel-repl-reporter babel-repl-console"></div>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.1.3/ace.js"></script>
-  <script src="{{ "/scripts/babel.js" | prepend: site.baseurl }}?t={{ site.time | date_to_xmlschema }}"></script>
-  <script src="{{ "/scripts/repl.js" | prepend: site.baseurl }}?t={{ site.time | date_to_xmlschema }}"></script>
 </div>

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -1,0 +1,29 @@
+$('.babel-slider').slick({
+  lazyLoad: 'ondemand',
+  arrows: false,
+  infinite: true,
+  speed: 500,
+  autoplay: true,
+  autoplaySpeed: 4000,
+  slidesToShow: 3,
+  slidesToScroll: 3,
+  responsive: [{
+    breakpoint: 1200,
+    settings: {
+      slidesToShow: 3,
+      slidesToScroll: 3
+    }
+  }, {
+    breakpoint: 992,
+    settings: {
+      slidesToShow: 2,
+      slidesToScroll: 2
+    }
+  }, {
+    breakpoint: 768,
+    settings: {
+      slidesToShow: 1,
+      slidesToScroll: 1
+    }
+  }]
+});

--- a/scripts/social.js
+++ b/scripts/social.js
@@ -1,0 +1,26 @@
+// Facebook
+(function(d, s, id) {
+  var js, fjs = d.getElementsByTagName(s)[0];
+  if (d.getElementById(id)) return;
+  js = d.createElement(s); js.id = id;
+  js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.0";
+  fjs.parentNode.insertBefore(js, fjs);
+}(document, 'script', 'facebook-jssdk'));
+// Twitter
+window.twttr = (function(d, s, id) {
+  var t, js, fjs = d.getElementsByTagName(s)[0];
+  if (d.getElementById(id)) return;
+  js = d.createElement(s); js.id = id;
+  js.src="https://platform.twitter.com/widgets.js";
+  fjs.parentNode.insertBefore(js, fjs);
+  return window.twttr || (t = { _e: [], ready: function(f) { t._e.push(f) } })
+}(document,"script","twitter-wjs"));
+// Disqus
+/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
+var disqus_shortname = '6to5'; // required: replace example with your forum shortname
+/* * * DON'T EDIT BELOW THIS LINE * * */
+(function() {
+    var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+    dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+})();


### PR DESCRIPTION
This PR literally moves all scripts to the bottom of the page - because #perfmatters.
The idea of these changes is to let author(s) of the page to easily add new client side code by modifying either page template (layout) file front metter declaration(s) or by modifying page front metter declaration(s).

For example - the web site is using Bootstrap framework cross-site. So the idea of solution in this PR is to declare that Bootstrap is to be used everywhere on the layout level:
```liquid
---
layout_external_scripts:
 - //cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js
 - //cdnjs.cloudflare.com/ajax/libs/lodash.js/2.4.1/lodash.min.js
 - //cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.1/js/bootstrap.min.js
---
```

and then simply use that information to write script tag into page body:
```liquid
{% if page.layout_external_scripts %}
  {% for script_path in page.layout_external_scripts %}
  <script src="{{ script_path }}"></script>
  {% endfor %}
{% endif %}
```

The local scripts are using cache busting solution.

As there could be 4 types of scripts (as the time of writing) within web site, there are 4 different lists declared:
- external on the layout level
- external on the page level
- local on the layout level
- local on the page level

The scripts are rendered later in the above list order (if they are declared and available in the `page` variable ofc).

This PR commits:
- remove render-blocking scripts from page haed section
- move embedded scripts from markup to JavaScript file
- prepare site-wide solution based on front metter declared variables
- specify layout related external and web site scripts in templates
- specify page specific external and web site scripts in templates
All scripts used on the website are now declared using list in front
metter sections. This allows to build up the correct order of script inclusion
in the given page and allows the future optimization if script minifying
is to be introduced.

![20150321221418](https://cloud.githubusercontent.com/assets/14539/6766893/1e9572a0-d019-11e4-80d4-267696ab7faf.jpg)

I've tried to test everything, comparing fetched scripts with current live version (and checking for scripts errors), but I'd ask someone to verify this PR as well.

@thejameskyle
This should improve overall page rendering speed and responsiveness.

Thanks!
