### PR TITLE
Fix some minor documentation spelling errors.

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -95,7 +95,7 @@ Simply disable it and reap the benefits of all the other transformers.
 
 ### Feature-rich
 
-The babel featureset is very comprehensive, supporting every ES6 syntactic feature. With
+The babel feature set is very comprehensive, supporting every ES6 syntactic feature. With
 built-in support for emerging standards such as [Flow](http://flowtype.org) and
 [JSX/React](/docs/usage/jsx) it makes it extremely easy to integrate.
 

--- a/docs/usage/loose.md
+++ b/docs/usage/loose.md
@@ -7,9 +7,9 @@ permalink: /docs/usage/loose/
 
 Loose mode enables certain transformers to generate cleaner output that lacks
 specific ES6 edgecases. These edgecases are either unlikely to appear in your
-code or the inclusion of them introduces signifcant overhead.
+code or the inclusion of them introduces significant overhead.
 
-As a result of loose mode code will execute faster and be much readable and
+As a result of loose mode code will execute faster and be much more readable and
 comparable to the original but will deviate from the spec in slight ways.
 
 <blockquote class="babel-callout babel-callout-warning">

--- a/docs/usage/require.md
+++ b/docs/usage/require.md
@@ -72,7 +72,7 @@ temporary directory.
 
 This will heavily improve with the startup and compilation of your files. There
 are however scenarios where you want to change this behaviour and there are
-environment varaibles exposed to allow you to do this.
+environment variables exposed to allow you to do this.
 
 ### BABEL_CACHE_PATH
 

--- a/docs/usage/runtime.md
+++ b/docs/usage/runtime.md
@@ -143,7 +143,7 @@ without worrying about where they come from.
 
 Usually babel will place helpers at the top of your file to do common tasks to avoid
 duplicating the code around in the current file. Sometimes these helpers can get a
-little bulky and add unneccessary duplication across files. The `runtime`
+little bulky and add unnecessary duplication across files. The `runtime`
 transformer replaces all the helper calls to a module.
 
 That means that the following code:


### PR DESCRIPTION
Noticed a few typos in the documentation as I was browsing.  Figured I'd fix them as I came across them.  