### PR TITLE
Allows commonjs getters to be defined

### DIFF
--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -3,7 +3,9 @@
   /* Throw meaningful errors for getters of commonjs. */
   ["module", "exports", "require"].forEach(function(commonVar){
     Object.defineProperty(window, commonVar, { 
-      get: function () { 
+      writable : true,
+      configurable : true,
+      get: function () {
         throw new Error(commonVar + " is not supported in the browser, you need a commonjs environment such as node.js/io.js, browserify/webpack etc");
       }
     });


### PR DESCRIPTION
So it's possible to overwrite those in the browser's console for testing. Examples:

```javascript
window.module = {};
window.module.exports = window.exports = {};
window.require = console.log.bind(console, 'require:');
```