### PR TITLE
fix references to es7.objectRestSpread

### DIFF
--- a/docs/usage/experimental.md
+++ b/docs/usage/experimental.md
@@ -40,7 +40,7 @@ point for inclusion by default in Babel due to their relative maturity and need 
 - [es7.asyncFunctions](https://github.com/lukehoban/ecmascript-asyncawait)
 - [es7.decorators](https://github.com/wycats/javascript-decorators)
 - [es7.exportExtensions](https://github.com/leebyron/ecmascript-more-export-from)
-- [es7.objectSpread](https://github.com/sebmarkbage/ecmascript-rest-spread)
+- [es7.objectRestSpread](https://github.com/sebmarkbage/ecmascript-rest-spread)
 
 ### Stage 2
 

--- a/docs/usage/transformers/index.md
+++ b/docs/usage/transformers/index.md
@@ -44,7 +44,7 @@ so that you can easily chain them together.
 - [es7.decorators](https://github.com/wycats/javascript-decorators)
 - [es7.exportExtensions](https://github.com/leebyron/ecmascript-more-export-from)
 - [es7.exponentiationOperator](https://github.com/rwaldron/exponentiation-operator)
-- [es7.objectSpread](https://github.com/sebmarkbage/ecmascript-rest-spread)
+- [es7.objectRestSpread](https://github.com/sebmarkbage/ecmascript-rest-spread)
 
 <blockquote class="babel-callout babel-callout-warning">
   <h4>Disabled by default</h4>


### PR DESCRIPTION
`es7.objectSpread` was changed to `es7.objectRestSpread` in v3.3.10 (https://github.com/babel/babel/commit/39fe737cb619357d321517f925cc3a3cf0004356), although it was not included in the [CHANGELOG](https://github.com/babel/babel/blob/master/CHANGELOG-6to5.md#3310).