### PR TITLE
Specify compilation and the babel-runtime for ES6 libraries

### DIFF
--- a/docs/usage/require.md
+++ b/docs/usage/require.md
@@ -13,7 +13,7 @@ fly. This is equivalent to CoffeeScript's
 <blockquote class="babel-callout babel-callout-warning">
   <h4>Not suitable for libraries</h4>
   <p>
-    The require hook automatically hooks itself into <strong>all</strong> node requires. This will pollute the global scope and introduce conflicts. Because of this it's not suitable for libraries, if however you're writing an application then it's completely fine to use.
+    The require hook automatically hooks itself into <strong>all</strong> node requires. This will pollute the global scope and introduce conflicts. If you're writing an application, it's completely fine to use. If, however, you're writing a library then you should compile your library and depend on the <a href="/docs/usage/runtime">babel-runtime</a>.
   </p>
 </blockquote>
 


### PR DESCRIPTION
When writing a library, it's clear a polyfill should be used and that the require hook automatically includes the polyfill. The warning that the require hook is not suitable for libraries offers no correct alternatives so this pull request updates the documentation on require hooks to point you to the recommend solution of compiling your library and depending on the babel-runtime.