### PR TITLE
Remove vertical tab acsii -� - from learn-es6.md

### DIFF
--- a/docs/learn-es6.md
+++ b/docs/learn-es6.md
@@ -533,25 +533,25 @@ logging/profiling, etc.
 
 ```js
 // Proxying a normal object
-var target = {};
-var handler = {
-  get: function (receiver, name) {
+var target = {};
+var handler = {
+  get: function (receiver, name) {
     return `Hello, ${name}!`;
-  }
-};
+  }
+};
 
-var p = new Proxy(target, handler);
+var p = new Proxy(target, handler);
 p.world === "Hello, world!";
 ```
 
 ```js
 // Proxying a function object
-var target = function () { return "I am the target"; };
+var target = function () { return "I am the target"; };
 var handler = {
   apply: function (receiver, ...args) {
     return "I am the proxy";
-  }
-};
+  }
+};
 
 var p = new Proxy(target, handler);
 p() === "I am the proxy";


### PR DESCRIPTION
Markdown doesn't seem to like rendering vertical tabs, as shown below:

![screen shot 2015-04-26 at 8 58 18 am](https://cloud.githubusercontent.com/assets/666638/7334893/5f356b92-ebf5-11e4-8a97-776f1be16ea2.png)

This small change removes all `^K` from the markdown. 