### PR TITLE
Update learn-es6 to clarify 'JavaScript'

### DIFF
--- a/docs/learn-es6.md
+++ b/docs/learn-es6.md
@@ -136,10 +136,10 @@ contents.
 
 ```js
 // Basic literal string creation
-`In JavaScript "\n" is a line-feed.`
+`In ES5 "\n" is a line-feed.`
 
 // Multiline strings
-`In JavaScript this is
+`In ES5 this is
  not legal.`
 
 // Interpolate variable bindings


### PR DESCRIPTION
Just replaced it by `ES5` as the doc title also uses the acronym - thought about adding `(commonly referred to as 'JavaScript')` but imho that's too much for these comments and should be treated as a prerequisite to learn ES6.