### PR TITLE
Clarifies "only" option

### DIFF
--- a/docs/usage/options.md
+++ b/docs/usage/options.md
@@ -27,7 +27,7 @@ $ babel --name=value
 | `optional`               | `[]`                 | Array of transformers to [optionally](/docs/usage/transformers#optional) use. Run `babel --help` to see a full list of transformers. Optional transformers displayed inside square brackets. |
 | `nonStandard`            | `true`               | Enable support for JSX and Flow. |
 | `highlightCode`          | `true`               | ANSI highlight syntax error code frames |
-| `only`                   | `null`               | An array of [glob](https://github.com/isaacs/minimatch) paths to **only** compile. When attempting to compile a non-matching file it's returned verbatim. |
+| `only`                   | `null`               | A [glob](https://github.com/isaacs/minimatch), regex, or mixed array of both, matching paths to **only** compile. Can also be an array of arrays containing paths to explicitly match. When attempting to compile a non-matching file it's returned verbatim. |
 | `ignore`                 | `null`               | Opposite to the `only` option. |
 | `jsxPragma`              | `null`               | Custom pragma to use for JSX elements |
 | `auxiliaryComment`       | `null`               | Attach a comment before all helper declarations and auxiliary code. eg. `"istanbul ignore next"` |

--- a/docs/usage/require.md
+++ b/docs/usage/require.md
@@ -45,7 +45,7 @@ override this by passing an ignore regex via:
 ```js
 require("babel/register")({
   // This will override `node_modules` ignoring - you can alternatively pass
-  // a regex
+  // an array of strings to be explicitly matched or a regex / glob
   ignore: false
 });
 ```


### PR DESCRIPTION
I looked up how the `only` option is treated in code to address #246.

### [babel-cli/bin/babel/index.js](https://github.com/babel/babel/blob/67201e969880e0435d7b20200d1e0d2695b5f863/packages/babel-cli/bin/babel/index.js#L112): 

`opts.only = util.arrayify(opts.only, util.regexify);`

### [api/register/node.js](https://github.com/babel/babel/blob/master/src/babel/api/register/node.js#L147)

`if (opts.only != null) onlyRegex = util.regexify(opts.only);`

`util.regexify` epects:

* glob (this can also be an explicit path)
* rexexp
* array of strings to match **exactly** 

Thus the `register` method currently can't handle an array of glob/regexp.

Corner case is currently passing in an array of arrays of strings to the cli, as these are joined by logical or (`|`) and escaped by `lodash`'s `excapeRegExp` instead of `minimatch`'s `makeRe`.
(But how do you pass an array of arrays via command line?)