### PR TITLE
Update repo for sprockets-es6

### DIFF
--- a/_includes/tools/rails/usage.md
+++ b/_includes/tools/rails/usage.md
@@ -10,6 +10,6 @@ require "sprockets/es6"
 
 <blockquote class="babel-callout babel-callout-info">
   <p>
-    For more information see the <a href="https://github.com/josh/sprockets-es6">josh/sprockets-es6 repo</a>.
+    For more information see the <a href="https://github.com/TannerRogalsky/sprockets-es6">TannerRogalsky/sprockets-es6 repo</a>.
   </p>
 </blockquote>

--- a/_includes/tools/sprockets/usage.md
+++ b/_includes/tools/sprockets/usage.md
@@ -10,6 +10,6 @@ require "sprockets/es6"
 
 <blockquote class="babel-callout babel-callout-info">
   <p>
-    For more information see the <a href="https://github.com/josh/sprockets-es6">josh/sprockets-es6 repo</a>.
+    For more information see the <a href="https://github.com/TannerRogalsky/sprockets-es6">TannerRogalsky/sprockets-es6 repo</a>.
   </p>
 </blockquote>


### PR DESCRIPTION
Previous repo mentioned in docs is now 404. Might be something @josh might provide more info about. //cc @TannerRogalsky