### PR TITLE
Fix quotes in Gemfile version of sprockets & sprockets-es6 mentioning

### DIFF
--- a/_includes/tools/rails/usage.md
+++ b/_includes/tools/rails/usage.md
@@ -1,7 +1,7 @@
 ```rb
 # Gemfile
-gem "sprockets"
-gem "sprockets-es6"
+gem 'sprockets'
+gem 'sprockets-es6'
 ```
 
 ```rb

--- a/_includes/tools/sprockets/usage.md
+++ b/_includes/tools/sprockets/usage.md
@@ -1,7 +1,7 @@
 ```rb
 # Gemfile
-gem "sprockets"
-gem "sprockets-es6"
+gem 'sprockets'
+gem 'sprockets-es6'
 ```
 
 ```rb


### PR DESCRIPTION
...to be more consistence with github.com/bbatsov/ruby-style-guide && Gemfile quotes coming with default rails project