### PR TITLE
Prevent overflowing text in featured button on mobile

### DIFF
--- a/_sass/components/_buttons.scss
+++ b/_sass/components/_buttons.scss
@@ -25,6 +25,7 @@
   font-family: $headings-font-family;
   font-size: $font-size-h1;
   padding: $padding-large-vertical $padding-large-horizontal * 2;
+  white-space: normal;
 
   &:not(:first-child) {
     margin-left: $padding-base-horizontal;


### PR DESCRIPTION
Prevent overflowing text in featured button on mobile (See image, 1 current, 2 after change).
![screen shot 2015-05-10 at 12 17 38](https://cloud.githubusercontent.com/assets/1774060/7553884/a34ae8a6-f70e-11e4-8b81-20c5609696fc.png)