### PR TITLE
Fix _interopRequire to match actual code

### DIFF
--- a/docs/usage/modules.md
+++ b/docs/usage/modules.md
@@ -144,9 +144,9 @@ export function bar() {
 define(["exports", "foo"], function (exports, _foo) {
   "use strict";
 
-  var _interopRequire = function (obj) {
-    return obj && (obj["default"] || obj);
-  };
+  function _interopRequire(obj) {
+    return obj && obj.__esModule ? obj["default"] : obj;
+  }
 
   exports.bar = bar;
   var foo = _interopRequire(_foo);
@@ -233,9 +233,9 @@ export function bar() {
 })(function (exports, _foo) {
   "use strict";
 
-  var _interopRequire = function (obj) {
-    return obj && (obj["default"] || obj);
-  };
+  function _interopRequire(obj) {
+    return obj && obj.__esModule ? obj["default"] : obj;
+  }
 
   exports.bar = bar;
   var foo = _interopRequire(_foo);


### PR DESCRIPTION
The docs showed the body of _interopRequire as being
```javascript
var _interopRequire = function (obj) {
  return obj && (obj["default"] || obj);
};
```
But the code in [https://github.com/babel/babel/blob/v5.3.3/src/babel/transformation/templates/helper-interop-require.js](helper-interop-require.js) shows:
```javascript
function (obj) {
  return obj && obj.__esModule ? obj.default : obj;
}
```