### PR TITLE
Correct size in Sets example.

### DIFF
--- a/docs/learn-es6.md
+++ b/docs/learn-es6.md
@@ -498,7 +498,7 @@ object-key’d side tables.
 // Sets
 var s = new Set();
 s.add("hello").add("goodbye").add("hello");
-s.size === 2;
+s.size === 3;
 s.has("hello") === true;
 
 // Maps


### PR DESCRIPTION
Should `s.size` not resolve to `3` instead of `2`?