### PR TITLE
Fix gulp task sequence. Put concat() after babel()

### DIFF
--- a/_includes/tools/gulp/usage.md
+++ b/_includes/tools/gulp/usage.md
@@ -22,8 +22,8 @@ var concat = require("gulp-concat");
 gulp.task("default", function () {
   return gulp.src("src/**/*.js")
     .pipe(sourcemaps.init())
-    .pipe(concat("all.js"))
     .pipe(babel())
+    .pipe(concat("all.js"))
     .pipe(sourcemaps.write("."))
     .pipe(gulp.dest("dist"));
 });


### PR DESCRIPTION
The concat operation should come after the babel transpilation step as seen here:
https://www.npmjs.com/package/gulp-babel

If someone was copying this doc as a gulpfile they could get errors when using modules.