### PR TITLE
Fix require for polyfill

### DIFF
--- a/docs/usage/polyfill.md
+++ b/docs/usage/polyfill.md
@@ -20,7 +20,7 @@ To include the polyfill you need to require it at the top of the **entry point**
 to your application.
 
 ```js
-require("babel/polyfill");
+require("babel-core/polyfill");
 ```
 
 Fortunately, this is also automatically loaded when using the
@@ -33,4 +33,4 @@ This needs to be included **before** all your compiled Babel code. You can eithe
 prepend it to your compiled code or include it in a `<script>`
 before it.
 
-**NOTE:** Do not `require` this via browserify etc, use `babel/polyfill`.
+**NOTE:** Do not `require` this via browserify etc, use `babel-core/polyfill`.


### PR DESCRIPTION
Webpack gave an error: Cannot resolve module 'babel/polyfill'