### PR TITLE
Clarify caveats: spreading Array doesn't require Array.from.

### DIFF
--- a/docs/advanced/caveats.md
+++ b/docs/advanced/caveats.md
@@ -23,7 +23,9 @@ You may alternatively selectively include what you need:
 | Async functions, Generators | [regenerator runtime](https://github.com/facebook/regenerator/blob/master/runtime.js) |
 | Comprehensions              | `Array.from`                                                                          |
 | For Of                      | `Symbol`, `prototype[Symbol.iterator]`                                                |
-| Spread                      | `Array.from`                                                                          |
+| Spread (on non-`Array`)     | `Array.from`                                                                          |
+
+Spreading an actual `Array`, including sparse arrays, does not require `Array.from`.
 
 ## Classes
 


### PR DESCRIPTION
EDIT: current branch: https://github.com/babel/babel.github.io/compare/master...jmm:caveats-spread2

The [Caveats](https://babeljs.io/docs/advanced/caveats/) page has a table of "certain features [that] require certain polyfills." One of the entries says that spread requires `Array.from`. That's not actually the case when spreading an `Array` (even a sparse array), and that seems to be intentional:

> [sebmck commented on Feb 11](https://github.com/babel/babel/issues/754#issuecomment-73873202)
> Not sure how to support this without forcing the polyfill on people who just want to spread/destructure arrays.

> [sebmck commented on Feb 11](https://github.com/babel/babel/issues/757#issuecomment-73939953)
> The point of special casing if it's an array is so the polyfill isn't required for array spread

If I'm reading this stuff right it seems straightforward to me that this should be documented. Why deliberately go to the trouble to make that work only to tell users it won't :)? Currently it says that `Array.from` is required for spread *period*. I read this like any other API documentation: if some usage of spread works without `Array.from`, it's just a side effect of implementation details and subject to not work in any other case or stop working at any time (any release or maybe even when updating deps).

Note: I haven't been able to build the site, so I haven't previewed these changes.