### PR TITLE
Prevent REPL console flip-flopping

### DIFF
--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -212,8 +212,9 @@
     }
   };
 
+  var capturingConsole;
   REPL.prototype.evaluate = function(code) {
-    var capturingConsole = Object.create(console);
+    capturingConsole = Object.create(console);
     var $consoleReporter = this.$consoleReporter;
     var buffer = [];
     var error;


### PR DESCRIPTION
If you use setTimeout/setImmediate your console can end up flipping between the current run and previous/outdated runs.


Reproducing:

1. Navigate to the repl (http://babeljs.io/repl/)

2. Ensure "Evaluate" is ticked

3. set the code to:

  ```js
  setInterval(function () {
    console.log('fooooooo');
  }, 1000)
  ```

4. Wait a couple of seconds

5. set the code to

  ```js
  setInterval(function () {
    console.log('barrrrrrrrr');
  }, 1000)
  ```

6. Observe the console flipping between lots of "fooooo" and lots of "barrrrrr"