### PR TITLE
Add missing .md file-extension

### DIFF
--- a/docs/usage/babelrc.md
+++ b/docs/usage/babelrc.md
@@ -5,7 +5,7 @@ description: How to use the babelrc
 permalink: /docs/usage/babelrc/
 ---
 
-The entire range of Babel API [options](/docs/usage/options) are allowed.
+The entire range of Babel API [options](/docs/usage/options.md) are allowed.
 
 **Example:**
 


### PR DESCRIPTION
Saw the broken link on the [.babelrc](https://github.com/babel/babel.github.io/blob/master/docs/usage/babelrc.md) page, fixed it by adding the missing .md file-extension