### PR TITLE
Added a note about non-standard file extensions to the description of the 'nonStandard' option.

### DIFF
--- a/docs/usage/options.md
+++ b/docs/usage/options.md
@@ -25,7 +25,7 @@ $ babel --name=value
 | `whitelist`              | `[]`                 | Array of transformers to **only** use. Run `babel --help` to see a full list of transformers. |
 | `loose`                  | `[]`                 | Array of transformers to enable [loose mode](/docs/advanced/loose) on. |
 | `optional`               | `[]`                 | Array of transformers to [optionally](/docs/advanced/transformers#optional) use. Run `babel --help` to see a full list of transformers. Optional transformers displayed inside square brackets. |
-| `nonStandard`            | `true`               | Enable support for JSX and Flow. |
+| `nonStandard`            | `true`               | Enable support for JSX and Flow. **NOTE:** To enable support for non-standard file extensions such as .jsx when using Node.js `require('./Component')`, see [Customizing extensions](https://github.com/babel/babelify#customising-extensions). |
 | `highlightCode`          | `true`               | ANSI highlight syntax error code frames |
 | `only`                   | `null`               | A [glob](https://github.com/isaacs/minimatch), regex, or mixed array of both, matching paths to **only** compile. Can also be an array of arrays containing paths to explicitly match. When attempting to compile a non-matching file it's returned verbatim. |
 | `ignore`                 | `null`               | Opposite to the `only` option. |


### PR DESCRIPTION
Use case: Many JSX developers mark their files as file.jsx. When using Node.js `require()` such as in a project using `Browserify`, `require()` will only search by .js and .json files for components by default. 

Currently when searching the docs, a user looking for "JSX" will look primarily at the `nonStandard` option since it enables support for JSX. However, many users are not aware that they will have to add a custom file extension to use `require()` to find components such as `require(./Component)` where Component is located in the file Component.jsx. 

Since this is a fairly common usage pattern, I have added a note to the description of the `nonStandard` option that alerts the user to look for additional information.