### PR TITLE
Fix brunch config example

### DIFF
--- a/_includes/tools/brunch/usage.md
+++ b/_includes/tools/brunch/usage.md
@@ -3,7 +3,7 @@ for `filename` and `sourceMap` which are handled internally.
 
 ```coffee
 plugins:
-  ESbabel:
+  babel:
     whitelist: ["arrowFunctions"]
     format:
       semicolons: false


### PR DESCRIPTION
The key for the plugin's config is just `babel`. It appears to have been listed as `ESbabel` because of a find/replace on the original key name `ES6to5`.