### PR TITLE
Update setup instructions for Meteor

### DIFF
--- a/_includes/tools/meteor/install.md
+++ b/_includes/tools/meteor/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ meteor add grigio:babel
+$ meteor add ecmascript
 ```

--- a/_includes/tools/meteor/usage.md
+++ b/_includes/tools/meteor/usage.md
@@ -1,7 +1,12 @@
-That's it! Any files with the extensions `.es6.js`, `.es6`, `.es` and `.jsx` will automatically be compiled with Babel.
+That's it! Any files with a `.js` extension will automatically be compiled
+with Babel.
+
+As of Meteor 1.2, the `ecmascript` package is installed by default for all
+new apps, so `meteor add ecmascript` is only necessary for existing apps.
 
 <blockquote class="babel-callout babel-callout-info">
   <p>
-    For more information see the <a href="https://github.com/grigio/meteor-babel">grigio/meteor-babel repo</a>.
+    For more information see the <code>ecmascript</code>
+    <a href="https://github.com/meteor/meteor/blob/master/packages/ecmascript/README.md">README.md</a>.
   </p>
 </blockquote>


### PR DESCRIPTION
ICYMI, Babel is installed by default for all new Meteor apps!