### PR TITLE
Enable line wrapping in ACE editor

### DIFF
--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -2,14 +2,14 @@
 
   /* Throw meaningful errors for getters of commonjs. */
   ["module", "exports", "require"].forEach(function(commonVar){
-    Object.defineProperty(window, commonVar, { 
+    Object.defineProperty(window, commonVar, {
       configurable: true,
       get: function () {
         throw new Error(commonVar + " is not supported in the browser, you need a commonjs environment such as node.js/io.js, browserify/webpack etc");
       }
     });
   });
-  
+
   /*
    * Utils for working with the browser's URI (e.g. the query params)
    */
@@ -96,6 +96,7 @@
     this.session.setUseSoftTabs(true);
     this.session.setTabSize(2);
     this.session.setUseWorker(false);
+    this.session.setUseWrapMode(true);
 
     this.editor.setOption('scrollPastEnd', 0.33);
   }
@@ -239,8 +240,8 @@
       capturingConsole.log.apply(capturingConsole, arguments);
     };
 
-    capturingConsole.log = 
-    capturingConsole.info = 
+    capturingConsole.log =
+    capturingConsole.info =
     capturingConsole.debug = function() {
       if (this !== capturingConsole) { return; }
 


### PR DESCRIPTION
About half the time I open the Babel REPL it's because I want to check the implementation of one of the helpers, and it's a lot harder to do that if I have to scroll horizontally to see anything. That said, this does look a little more cluttered if you're _not_ interested in the helpers, so I understand if you don't want this.

![screenshot of Babel REPL with line wrapping enabled](https://cloud.githubusercontent.com/assets/6820/10144988/6b3503f8-65d5-11e5-8485-2804b3f550ec.png)