### PR TITLE
[Manipulation] Replace remove by dangerouslyRemove

### DIFF
--- a/docs/advanced/plugins/manipulation.md
+++ b/docs/advanced/plugins/manipulation.md
@@ -117,7 +117,7 @@ export default function ({ Plugin, types: t }) {
   return new Plugin("foo-bar", {
     visitor: {
       FunctionDeclaration(node, parent) {
-        this.parentPath.remove();
+        this.parentPath.dangerouslyRemove();
       }
     }
   });


### PR DESCRIPTION
I have this following warning `Path#remove has been renamed to Path#dangerouslyRemove, removing a node is extremely dangerous so please refrain using it.`. I'm assuming the doc is not up to date.