### PR TITLE
Inform about babel-node limitations.

### DIFF
--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -91,9 +91,9 @@ $ babel --out-file script-compiled.js < script.js
   </p>
 </blockquote>
 <blockquote class="babel-callout babel-callout-info">
-  <h4>ES6-style module-loading is not supported</h4>
+  <h4>ES6-style module-loading may not function as expected</h4>
   <p>
-    Due to technical limitations ES6-style module-loading is not supported in <code>babel-node</code>.
+    Due to technical limitations ES6-style module-loading is not fully supported in a <code>babel-node REPL</code>.
   </p>
 </blockquote>
 

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -90,6 +90,13 @@ $ babel --out-file script-compiled.js < script.js
     experience a startup performance penalty as the entire app needs to be compiled on the fly.
   </p>
 </blockquote>
+<blockquote class="babel-callout babel-callout-info">
+  <h4>ES6-style module-loading is not supported</h4>
+  <p>
+    Due to technical limitations ES6-style module-loading is not supported in <code>babel-node</code>.
+  </p>
+</blockquote>
+
 
 babel comes with a second CLI which works exactly the same as Node.js's CLI, only
 it will compile ES6 code before running it.


### PR DESCRIPTION
Include a callout to inform users that ES6-style module loading is not supported in `babel-node`.