### PR TITLE
Add clarifications about supported ES6 methods to caveats

### DIFF
--- a/docs/advanced/caveats.md
+++ b/docs/advanced/caveats.md
@@ -28,7 +28,9 @@ You may alternatively selectively include what you need:
 ## Classes
 
 Built-in classes such as `Date`, `Array`, `DOM` etc cannot be properly subclassed
-due to limitations in ES5.
+due to limitations in ES5. This means, because Babel can't distinguish between 
+`(arr).includes()` and `(str).includes()` statically, you'll have to use [the
+polyfill](/docs/usage/polyfill/) to use these methods.
 
 ## ES5
 


### PR DESCRIPTION
Babel can't distinguish between `arr.includes` and `str.includes` at compile time, so we added clarifications around why these methods might be missing (can't be inferred statically at compile-time) and a workaround (use the polyfill).

Happy for feedback on the wording here, I think this info should be included more obviously in more places, especially since the high-level proposition to developers is "Use next generation JavaScript, today." and we tout these methods (only supported with additional polyfill) in [our overview of ES2016 features](http://babeljs.io/docs/learn-es2015/#math-number-string-object-apis)