### PR TITLE
Setup Babel.js with Jasmine

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -26,9 +26,10 @@
     sails: Sails
 - name: Test frameworks
   items:
-    mocha: Mocha
+    jasmine: Jasmine
     jest: Jest
     karma: Karma
+    mocha: Mocha
 - name: Utilities
   items:
     connect: Connect

--- a/_includes/tools/jasmine/install.md
+++ b/_includes/tools/jasmine/install.md
@@ -1,0 +1,3 @@
+```sh
+$ npm install --save-dev babel
+```

--- a/_includes/tools/jasmine/usage.md
+++ b/_includes/tools/jasmine/usage.md
@@ -1,0 +1,17 @@
+In your `spec/support/jasmine.json` file make the following changes:
+
+```json
+{
+  "helpers": [
+    "../../node_modules/babel-core/register.js"
+  ]
+}
+```
+
+This file is create when you setup project with `jasmine init` command.
+
+<blockquote class="babel-callout babel-callout-info">
+  <p>
+    For more information see the <a href="https://github.com/piecioshka/test-jasmine-babel">piecioshka/test-jasmine-babel repo</a>.
+  </p>
+</blockquote>


### PR DESCRIPTION
Hi @sebmck and @thejameskyle!

By this PR I wil try to explain, how to use Babel.js with Jasmine project.

Often I will setup unit tests by run command `jasmine init`.
This command creates simple json, eg:

```json
{
  "spec_dir": "spec",
  "spec_files": [
    "**/*[sS]pec.js"
  ],
  "helpers": [
    "helpers/**/*.js"
  ]
}
```

I would like to use ES6 syntax with my unit tests but without compiling it is imposible.
I love Babel.js and will try to help people how to (by adds simple line) write specs in ES6.

```json
{
  "helpers": [
    "../../node_modules/babel-core/register.js",
    "helpers/**/*.js"
  ]
}
```

After adding reference to `register.js` my specs (written in ES6) are properly parsed.

What are thinking about this?