### PR TITLE
Fixes trivial typos

### DIFF
--- a/_posts/2015-10-29-6.0.0.md
+++ b/_posts/2015-10-29-6.0.0.md
@@ -43,7 +43,7 @@ If there’s something you want to build with some Babel internals, you can now 
 
 Since Babel is focusing on being a platform for JavaScript tooling and not an ES2015 transpiler, we’ve decided to make all of the plugins opt-in. This means when you install Babel it will no longer transpile your ES2015 code by default.
 
-In order to drastically simplify the public API of Babel, each transfromer is now completely independent. This means the ‘blacklist’, ‘whitelist’, ‘optional’, ‘nonStandard’, and ‘modules’ options have all been removed, but that doesn’t mean you need to do more work to get Babel to transform your codebase.
+In order to drastically simplify the public API of Babel, each transformer is now completely independent. This means the ‘blacklist’, ‘whitelist’, ‘optional’, ‘nonStandard’, and ‘modules’ options have all been removed, but that doesn’t mean you need to do more work to get Babel to transform your codebase.
 
 ### Plugin Presets
 
@@ -65,7 +65,7 @@ The official presets included today are `babel-preset-es2015` and `babel-preset-
 
 Performance continues to be one of the top priorities of Babel. Babel 5 changed the transformation and traversal pipeline dramatically to make way for some major performance improvements that have been implemented in Babel 6.
 
-The traversal process is one of biggest chunks of time spent in the Babel pipeline. With any AST-based tool you want to make sure that you traverse the tree as little as possible to keep it fast. Plugins were designed around this so that they could be lighting fast while working with everything else.
+The traversal process is one of biggest chunks of time spent in the Babel pipeline. With any AST-based tool you want to make sure that you traverse the tree as little as possible to keep it fast. Plugins were designed around this so that they could be lightning fast while working with everything else.
 
 Babel 6 implements a new optimization which merges all plugins together into a single traversal. It then manages the traversal process completely so plugins don’t ever have to worry about doing so manually. As a developer you can simply focus on writing your transform, and Babel will handle the rest.
 
@@ -93,7 +93,7 @@ export default function({ types: t }) {
 }
 ```
 
-> **Plugin Authors**: When updating your plugins, please remember to bump your major versions since this make Babel 5 and 6 incompatible. Semver is important!
+> **Plugin Authors**: When updating your plugins, please remember to bump your major versions since this makes Babel 5 and 6 incompatible. Semver is important!
 
 ### New/Updated Proposals
 


### PR DESCRIPTION
Thanks for the hard work, Babel team! I love using it. 
Just wanted to help in the tiniest of ways by cleaning up a few insignificant typos in the big v6 announcement. 