### PR TITLE
Add Github and npm links to package docs

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -8,6 +8,9 @@ layout: default
       <div class="col-md-12">
         <h1>{{page.title}}</h1>
         <p>{{page.description}}</p>
+        {% if page.package %}
+        <p class="package-links"><a href="https://github.com/babel/babel/tree/master/packages/{{page.package}}">GitHub</a>&nbsp; · &nbsp;<a href="https://www.npmjs.com/package/{{page.package}}">npm</a></p>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/_sass/pages/_docs.scss
+++ b/_sass/pages/_docs.scss
@@ -12,8 +12,11 @@
     font-weight: 700;
   }
 
-  p {
+  p:not(.package-links) {
     font-size: 1.5em;
+  }
+
+  p, a {
     color: white;
   }
 }

--- a/_sass/pages/_docs.scss
+++ b/_sass/pages/_docs.scss
@@ -12,12 +12,17 @@
     font-weight: 700;
   }
 
-  p:not(.package-links) {
-    font-size: 1.5em;
+  p {
+    color: white;
+
+    &:not(.package-links) {
+      font-size: 1.5em;
+    }
   }
 
-  p, a {
-    color: white;
+  a {
+    color: $babel-yellow;
+    text-decoration: underline;
   }
 }
 

--- a/docs/plugins/external-helpers.md
+++ b/docs/plugins/external-helpers.md
@@ -3,6 +3,7 @@ layout: docs
 title: External helpers
 description:
 permalink: /docs/plugins/external-helpers/
+package: babel-plugin-external-helpers-2
 ---
 
 ## Installation

--- a/docs/plugins/preset-es2015.md
+++ b/docs/plugins/preset-es2015.md
@@ -3,6 +3,7 @@ layout: docs
 title: ES2015 preset
 description: All you need to compile ES2015 to ES5
 permalink: /docs/plugins/preset-es2015/
+package: babel-preset-es2015
 ---
 
 This preset includes the following plugins:

--- a/docs/plugins/preset-react.md
+++ b/docs/plugins/preset-react.md
@@ -3,6 +3,7 @@ layout: docs
 title: React preset
 description: Strip flow types and transform JSX into createElement calls.
 permalink: /docs/plugins/preset-react/
+package: babel-preset-react
 ---
 
 This preset includes the following plugins:

--- a/docs/plugins/preset-stage-0.md
+++ b/docs/plugins/preset-stage-0.md
@@ -3,6 +3,7 @@ layout: docs
 title: Stage 0 preset
 description: All you need to use stage 0 (and greater) plugins
 permalink: /docs/plugins/preset-stage-0/
+package: babel-preset-stage-0
 ---
 
 This preset includes the following plugins:

--- a/docs/plugins/preset-stage-1.md
+++ b/docs/plugins/preset-stage-1.md
@@ -3,6 +3,7 @@ layout: docs
 title: Stage 1 preset
 description: All you need to use stage 1 (and greater) plugins
 permalink: /docs/plugins/preset-stage-1/
+package: babel-preset-stage-1
 ---
 
 This preset includes the following plugins:

--- a/docs/plugins/preset-stage-2.md
+++ b/docs/plugins/preset-stage-2.md
@@ -3,6 +3,7 @@ layout: docs
 title: Stage 2 preset
 description: All you need to use stage 2 (and greater) plugins
 permalink: /docs/plugins/preset-stage-2/
+package: babel-preset-stage-2
 ---
 
 This preset includes the following plugins:

--- a/docs/plugins/preset-stage-3.md
+++ b/docs/plugins/preset-stage-3.md
@@ -3,6 +3,7 @@ layout: docs
 title: Stage 3 preset
 description: All you need to use stage 3 plugins
 permalink: /docs/plugins/preset-stage-3/
+package: babel-preset-stage-3
 ---
 
 This preset includes the following plugins:

--- a/docs/plugins/syntax-async-functions.md
+++ b/docs/plugins/syntax-async-functions.md
@@ -3,6 +3,7 @@ layout: docs
 title: Syntax async functions
 description:
 permalink: /docs/plugins/syntax-async-functions/
+package: babel-plugin-syntax-async-functions
 ---
 
 This plugin allows Babel to parse [async functions](https://github.com/tc39/ecmascript-asyncawait).

--- a/docs/plugins/syntax-async-generators.md
+++ b/docs/plugins/syntax-async-generators.md
@@ -3,6 +3,7 @@ layout: docs
 title: Syntax async generators
 description:
 permalink: /docs/plugins/syntax-async-generators/
+package: babel-plugin-syntax-async-generators
 ---
 
 This plugin allows Babel to parse [async generators](https://github.com/zenparsing/async-iteration/).

--- a/docs/plugins/syntax-class-constructor-call.md
+++ b/docs/plugins/syntax-class-constructor-call.md
@@ -3,6 +3,7 @@ layout: docs
 title: Class constructor call
 description:
 permalink: /docs/plugins/syntax-class-constructor-call/
+package: babel-plugin-syntax-class-constructor-call
 ---
 
 <blockquote class="babel-callout babel-callout-info">

--- a/docs/plugins/syntax-class-properties.md
+++ b/docs/plugins/syntax-class-properties.md
@@ -3,6 +3,7 @@ layout: docs
 title: Syntax class properties
 description:
 permalink: /docs/plugins/syntax-class-properties/
+package: babel-plugin-syntax-class-properties
 ---
 
 <blockquote class="babel-callout babel-callout-info">

--- a/docs/plugins/syntax-decorators.md
+++ b/docs/plugins/syntax-decorators.md
@@ -3,6 +3,7 @@ layout: docs
 title: Syntax decorators
 description:
 permalink: /docs/plugins/syntax-decorators/
+package: babel-plugin-syntax-decorators
 ---
 
 <blockquote class="babel-callout babel-callout-info">

--- a/docs/plugins/syntax-do-expressions.md
+++ b/docs/plugins/syntax-do-expressions.md
@@ -3,6 +3,7 @@ layout: docs
 title: Syntax do expressions
 description:
 permalink: /docs/plugins/syntax-do-expressions/
+package: babel-plugin-syntax-do-expressions
 ---
 
 <blockquote class="babel-callout babel-callout-info">

--- a/docs/plugins/syntax-exponentiation-operator.md
+++ b/docs/plugins/syntax-exponentiation-operator.md
@@ -3,6 +3,7 @@ layout: docs
 title: Syntax exponentiation operator
 description:
 permalink: /docs/plugins/syntax-exponentiation-operator/
+package: babel-plugin-syntax-exponentiation-operator
 ---
 
 <blockquote class="babel-callout babel-callout-info">

--- a/docs/plugins/syntax-export-extensions.md
+++ b/docs/plugins/syntax-export-extensions.md
@@ -3,6 +3,7 @@ layout: docs
 title: Syntax export extensions
 description:
 permalink: /docs/plugins/syntax-export-extensions/
+package: babel-plugin-syntax-export-extensions
 ---
 
 <blockquote class="babel-callout babel-callout-info">

--- a/docs/plugins/syntax-flow.md
+++ b/docs/plugins/syntax-flow.md
@@ -3,6 +3,7 @@ layout: docs
 title: Syntax flow
 description:
 permalink: /docs/plugins/syntax-flow/
+package: babel-plugin-syntax-flow
 ---
 
 <blockquote class="babel-callout babel-callout-info">

--- a/docs/plugins/syntax-function-bind.md
+++ b/docs/plugins/syntax-function-bind.md
@@ -3,6 +3,7 @@ layout: docs
 title: Syntax function bind
 description:
 permalink: /docs/plugins/syntax-function-bind/
+package: babel-plugin-syntax-function-bind
 ---
 
 <blockquote class="babel-callout babel-callout-info">

--- a/docs/plugins/syntax-jsx.md
+++ b/docs/plugins/syntax-jsx.md
@@ -3,6 +3,7 @@ layout: docs
 title: Syntax JSX
 description:
 permalink: /docs/plugins/syntax-jsx/
+package: babel-plugin-syntax-jsx
 ---
 
 <blockquote class="babel-callout babel-callout-info">

--- a/docs/plugins/syntax-object-rest-spread.md
+++ b/docs/plugins/syntax-object-rest-spread.md
@@ -3,6 +3,7 @@ layout: docs
 title: Syntax object rest spread
 description:
 permalink: /docs/plugins/syntax-object-rest-spread/
+package: babel-plugin-syntax-object-rest-spread
 ---
 
 

--- a/docs/plugins/syntax-trailing-function-commas.md
+++ b/docs/plugins/syntax-trailing-function-commas.md
@@ -3,6 +3,7 @@ layout: docs
 title: Syntax trailing function commas
 description:
 permalink: /docs/plugins/syntax-trailing-function-commas/
+package: babel-plugin-syntax-trailing-function-commas
 ---
 
 

--- a/docs/plugins/transform-async-to-generator.md
+++ b/docs/plugins/transform-async-to-generator.md
@@ -3,6 +3,7 @@ layout: docs
 title: Async to generator transform
 description:
 permalink: /docs/plugins/transform-async-to-generator/
+package: babel-plugin-transform-async-to-generator
 ---
 
 ## Example

--- a/docs/plugins/transform-async-to-module-method.md
+++ b/docs/plugins/transform-async-to-module-method.md
@@ -3,6 +3,7 @@ layout: docs
 title: Async function to module method transform
 description:
 permalink: /docs/plugins/transform-async-to-module-method/
+package: babel-plugin-transform-async-to-module-method
 ---
 
 ## Installation

--- a/docs/plugins/transform-class-constructor-call.md
+++ b/docs/plugins/transform-class-constructor-call.md
@@ -3,6 +3,7 @@ layout: docs
 title: Callable class constructor transform
 description:
 permalink: /docs/plugins/transform-class-constructor-call/
+package: babel-plugin-transform-class-constructor-call
 ---
 
 ## Installation

--- a/docs/plugins/transform-class-properties.md
+++ b/docs/plugins/transform-class-properties.md
@@ -3,6 +3,7 @@ layout: docs
 title: Class properties transform
 description:
 permalink: /docs/plugins/transform-class-properties/
+package: babel-plugin-transform-class-properties
 ---
 
 ## Installation

--- a/docs/plugins/transform-decorators.md
+++ b/docs/plugins/transform-decorators.md
@@ -3,6 +3,7 @@ layout: docs
 title: Decorators transform
 description:
 permalink: /docs/plugins/transform-decorators/
+package: babel-plugin-transform-decorators
 ---
 
 ## Installation

--- a/docs/plugins/transform-do-expressions.md
+++ b/docs/plugins/transform-do-expressions.md
@@ -3,6 +3,7 @@ layout: docs
 title: Do expressions transform
 description:
 permalink: /docs/plugins/transform-do-expressions/
+package: babel-plugin-transform-do-expressions
 ---
 
 ## Installation

--- a/docs/plugins/transform-es2015-arrow-functions.md
+++ b/docs/plugins/transform-es2015-arrow-functions.md
@@ -3,6 +3,7 @@ layout: docs
 title: ES2015 arrow functions transform
 description:
 permalink: /docs/plugins/transform-es2015-arrow-functions/
+package: babel-plugin-transform-es2015-arrow-functions
 ---
 
 ## Installation

--- a/docs/plugins/transform-es2015-block-scoped-functions.md
+++ b/docs/plugins/transform-es2015-block-scoped-functions.md
@@ -3,6 +3,7 @@ layout: docs
 title: ES2015 block scoped functions transform
 description:
 permalink: /docs/plugins/transform-es2015-block-scoped-functions/
+package: babel-plugin-transform-es2015-block-scoped-functions
 ---
 
 ## Installation

--- a/docs/plugins/transform-es2015-block-scoping.md
+++ b/docs/plugins/transform-es2015-block-scoping.md
@@ -3,6 +3,7 @@ layout: docs
 title: ES2015 block scoping transform
 description:
 permalink: /docs/plugins/transform-es2015-block-scoping/
+package: babel-plugin-transform-es2015-block-scoping
 ---
 
 ## Installation

--- a/docs/plugins/transform-es2015-classes.md
+++ b/docs/plugins/transform-es2015-classes.md
@@ -3,6 +3,7 @@ layout: docs
 title: ES2015 classes transform
 description:
 permalink: /docs/plugins/transform-es2015-classes/
+package: babel-plugin-transform-es2015-classes
 ---
 
 ## Installation

--- a/docs/plugins/transform-es2015-computed-properties.md
+++ b/docs/plugins/transform-es2015-computed-properties.md
@@ -3,6 +3,7 @@ layout: docs
 title: ES2015 computed-properties transform
 description:
 permalink: /docs/plugins/transform-es2015-computed-properties/
+package: babel-plugin-transform-es2015-computed-properties
 ---
 
 ## Installation

--- a/docs/plugins/transform-es2015-constants.md
+++ b/docs/plugins/transform-es2015-constants.md
@@ -3,6 +3,7 @@ layout: docs
 title: ES2015 constants transform
 description:
 permalink: /docs/plugins/transform-es2015-constants/
+package: babel-plugin-transform-es2015-constants
 ---
 
 ## Installation

--- a/docs/plugins/transform-es2015-destructuring.md
+++ b/docs/plugins/transform-es2015-destructuring.md
@@ -3,6 +3,7 @@ layout: docs
 title: ES2015 destructuring transform
 description:
 permalink: /docs/plugins/transform-es2015-destructuring/
+package: babel-plugin-transform-es2015-destructuring
 ---
 
 ## Installation

--- a/docs/plugins/transform-es2015-for-of.md
+++ b/docs/plugins/transform-es2015-for-of.md
@@ -3,6 +3,7 @@ layout: docs
 title: ES2015 for-of transform
 description:
 permalink: /docs/plugins/transform-es2015-for-of/
+package: babel-plugin-transform-es2015-for-of
 ---
 
 This plugin transforms ES2015 for of loops to ES5.

--- a/docs/plugins/transform-es2015-function-name.md
+++ b/docs/plugins/transform-es2015-function-name.md
@@ -3,6 +3,7 @@ layout: docs
 title: ES2015 function name transform
 description:
 permalink: /docs/plugins/transform-es2015-function-name/
+package: babel-plugin-transform-es2015-function-name
 ---
 
 ## Installation

--- a/docs/plugins/transform-es2015-literals.md
+++ b/docs/plugins/transform-es2015-literals.md
@@ -3,6 +3,7 @@ layout: docs
 title: ES2015 literals transform
 description:
 permalink: /docs/plugins/transform-es2015-literals/
+package: babel-plugin-transform-es2015-literals
 ---
 
 ## Installation

--- a/docs/plugins/transform-es2015-modules-amd.md
+++ b/docs/plugins/transform-es2015-modules-amd.md
@@ -3,6 +3,7 @@ layout: docs
 title: ES2015 modules to AMD transform
 description:
 permalink: /docs/plugins/transform-es2015-modules-amd/
+package: babel-plugin-transform-es2015-modules-amd
 ---
 
 This plugin transforms ES2015 modules to AMD.

--- a/docs/plugins/transform-es2015-modules-commonjs.md
+++ b/docs/plugins/transform-es2015-modules-commonjs.md
@@ -3,6 +3,7 @@ layout: docs
 title: ES2015 modules to CommonJS transform
 description:
 permalink: /docs/plugins/transform-es2015-modules-commonjs/
+package: babel-plugin-transform-es2015-modules-commonjs
 ---
 
 This plugin transforms ES2015 modules to CommonJS.

--- a/docs/plugins/transform-es2015-modules-systemjs.md
+++ b/docs/plugins/transform-es2015-modules-systemjs.md
@@ -3,6 +3,7 @@ layout: docs
 title: ES2015 modules to SystemJS transform
 description:
 permalink: /docs/plugins/transform-es2015-modules-systemjs/
+package: babel-plugin-transform-es2015-modules-systemjs
 ---
 
 This plugin transforms ES2015 modules to SystemJS.

--- a/docs/plugins/transform-es2015-modules-umd.md
+++ b/docs/plugins/transform-es2015-modules-umd.md
@@ -3,6 +3,7 @@ layout: docs
 title: ES2015 modules to UMD transform
 description:
 permalink: /docs/plugins/transform-es2015-modules-umd/
+package: babel-plugin-transform-es2015-modules-umd
 ---
 
 This plugin transforms ES2015 modules to UMD.

--- a/docs/plugins/transform-es2015-object-super.md
+++ b/docs/plugins/transform-es2015-object-super.md
@@ -3,6 +3,7 @@ layout: docs
 title: ES2015 object super transform
 description:
 permalink: /docs/plugins/transform-es2015-object-super/
+package: babel-plugin-transform-es2015-object-super
 ---
 
 ## Installation

--- a/docs/plugins/transform-es2015-parameters.md
+++ b/docs/plugins/transform-es2015-parameters.md
@@ -3,6 +3,7 @@ layout: docs
 title: ES2015 parameters transform
 description:
 permalink: /docs/plugins/transform-es2015-parameters/
+package: babel-plugin-transform-es2015-parameters
 ---
 
 This plugin transforms ES2015 parameters to ES5, this includes:

--- a/docs/plugins/transform-es2015-shorthand-properties.md
+++ b/docs/plugins/transform-es2015-shorthand-properties.md
@@ -3,6 +3,7 @@ layout: docs
 title: ES2015 shorthand properties transform
 description:
 permalink: /docs/plugins/transform-es2015-shorthand-properties/
+package: babel-plugin-transform-es2015-shorthand-properties
 ---
 
 ## Installation

--- a/docs/plugins/transform-es2015-spread.md
+++ b/docs/plugins/transform-es2015-spread.md
@@ -3,6 +3,7 @@ layout: docs
 title: ES2015 spread transform
 description:
 permalink: /docs/plugins/transform-es2015-spread/
+package: babel-plugin-transform-es2015-spread
 ---
 
 ## Installation

--- a/docs/plugins/transform-es2015-sticky-regex.md
+++ b/docs/plugins/transform-es2015-sticky-regex.md
@@ -3,6 +3,7 @@ layout: docs
 title: ES2015 sticky regex transform
 description:
 permalink: /docs/plugins/transform-es2015-sticky-regex/
+package: babel-plugin-transform-es2015-sticky-regex
 ---
 
 ## Installation

--- a/docs/plugins/transform-es2015-template-literals.md
+++ b/docs/plugins/transform-es2015-template-literals.md
@@ -3,6 +3,7 @@ layout: docs
 title: ES2015 template literals transform
 description:
 permalink: /docs/plugins/transform-es2015-template-literals/
+package: babel-plugin-transform-es2015-template-literals
 ---
 
 ## Installation

--- a/docs/plugins/transform-es2015-typeof-symbol.md
+++ b/docs/plugins/transform-es2015-typeof-symbol.md
@@ -3,6 +3,7 @@ layout: docs
 title: ES2015 typeof symbol transform
 description:
 permalink: /docs/plugins/transform-es2015-typeof-symbol/
+package: babel-plugin-transform-es2015-typeof-symbol
 ---
 
 ## Installation

--- a/docs/plugins/transform-es2015-unicode-regex.md
+++ b/docs/plugins/transform-es2015-unicode-regex.md
@@ -3,6 +3,7 @@ layout: docs
 title: ES2015 unicode regex transform
 description:
 permalink: /docs/plugins/transform-es2015-unicode-regex/
+package: babel-plugin-transform-es2015-unicode-regex
 ---
 
 ## Installation

--- a/docs/plugins/transform-es3-member-expression-literals.md
+++ b/docs/plugins/transform-es3-member-expression-literals.md
@@ -3,6 +3,7 @@ layout: docs
 title: ES3 member expressions literals transform
 description:
 permalink: /docs/plugins/transform-es3-member-expression-literals/
+package: babel-plugin-transform-es3-member-expression-literals
 ---
 
 Turn member expression reserved word properties into literals.

--- a/docs/plugins/transform-es3-property-literals.md
+++ b/docs/plugins/transform-es3-property-literals.md
@@ -3,6 +3,7 @@ layout: docs
 title: ES3 property literals transform
 description:
 permalink: /docs/plugins/transform-es3-property-literals/
+package: babel-plugin-transform-es3-property-literals
 ---
 
 Turn reserved word property keys into literals.

--- a/docs/plugins/transform-es5-property-mutators.md
+++ b/docs/plugins/transform-es5-property-mutators.md
@@ -3,6 +3,7 @@ layout: docs
 title: ES5 property mutators transform
 description:
 permalink: /docs/plugins/transform-es5-property-mutators/
+package: babel-plugin-transform-es5-property-mutators
 ---
 
 Turn [object initializer mutators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#Method_definitions) into `Object.defineProperties`.

--- a/docs/plugins/transform-eval.md
+++ b/docs/plugins/transform-eval.md
@@ -3,6 +3,7 @@ layout: docs
 title: Eval transform
 description:
 permalink: /docs/plugins/transform-eval/
+package: babel-plugin-transform-eval
 ---
 
 ## Installation

--- a/docs/plugins/transform-exponentiation-operator.md
+++ b/docs/plugins/transform-exponentiation-operator.md
@@ -3,6 +3,7 @@ layout: docs
 title: Exponentiation operator transform
 description:
 permalink: /docs/plugins/transform-exponentiation-operator/
+package: babel-plugin-transform-exponentiation-operator
 ---
 
 ## Installation

--- a/docs/plugins/transform-export-extensions.md
+++ b/docs/plugins/transform-export-extensions.md
@@ -3,6 +3,7 @@ layout: docs
 title: Export extensions transform
 description:
 permalink: /docs/plugins/transform-export-extensions/
+package: babel-plugin-transform-export-extensions
 ---
 
 ## Installation

--- a/docs/plugins/transform-flow-strip-types.md
+++ b/docs/plugins/transform-flow-strip-types.md
@@ -3,6 +3,7 @@ layout: docs
 title: Strip flow types transform
 description:
 permalink: /docs/plugins/transform-flow-strip-types/
+package: babel-plugin-transform-flow-strip-types
 ---
 
 This plugin strips all flow type annotations and declarations.

--- a/docs/plugins/transform-function-bind.md
+++ b/docs/plugins/transform-function-bind.md
@@ -3,6 +3,7 @@ layout: docs
 title: Function bind transform
 description:
 permalink: /docs/plugins/transform-function-bind/
+package: babel-plugin-transform-function-bind
 ---
 
 ## Installation

--- a/docs/plugins/transform-inline-environment-variables.md
+++ b/docs/plugins/transform-inline-environment-variables.md
@@ -3,6 +3,7 @@ layout: docs
 title: Inline environment variables transform
 description:
 permalink: /docs/plugins/transform-inline-environment-variables/
+package: babel-plugin-transform-inline-environment-variables
 ---
 
 Inlines environment variables.

--- a/docs/plugins/transform-jscript.md
+++ b/docs/plugins/transform-jscript.md
@@ -3,6 +3,7 @@ layout: docs
 title: JScript transform
 description:
 permalink: /docs/plugins/transform-jscript/
+package: babel-plugin-transform-jscript
 ---
 
 This transformer transforms named function expressions into function declarations to get around some

--- a/docs/plugins/transform-member-expression-literals.md
+++ b/docs/plugins/transform-member-expression-literals.md
@@ -3,6 +3,7 @@ layout: docs
 title: Member expression literals transform
 description:
 permalink: /docs/plugins/transform-member-expression-literals/
+package: babel-plugin-transform-member-expression-literals
 ---
 
 Turn member expression valid identifier literal properties into identifiers.

--- a/docs/plugins/transform-merge-sibling-variables.md
+++ b/docs/plugins/transform-merge-sibling-variables.md
@@ -3,6 +3,7 @@ layout: docs
 title: Merge sibling variables transform
 description:
 permalink: /docs/plugins/transform-merge-sibling-variables/
+package: babel-plugin-transform-merge-sibling-variables
 ---
 
 Merge sibling variable declarations.

--- a/docs/plugins/transform-minify-booleans.md
+++ b/docs/plugins/transform-minify-booleans.md
@@ -3,6 +3,7 @@ layout: docs
 title: Minify booleans transform
 description:
 permalink: /docs/plugins/transform-minify-booleans/
+package: babel-plugin-transform-minify-booleans
 ---
 
 Turn boolean literals into `!0` for `true` and `!1` for `false`.

--- a/docs/plugins/transform-node-env-inline.md
+++ b/docs/plugins/transform-node-env-inline.md
@@ -3,6 +3,7 @@ layout: docs
 title: NODE_ENV inline transform
 description:
 permalink: /docs/plugins/transform-node-env-inline/
+package: babel-plugin-transform-node-env-inline
 ---
 
 ## Installation

--- a/docs/plugins/transform-object-assign.md
+++ b/docs/plugins/transform-object-assign.md
@@ -3,6 +3,7 @@ layout: docs
 title: Object.assign transform
 description:
 permalink: /docs/plugins/transform-object-assign/
+package: babel-plugin-transform-object-assign
 ---
 
 ## Installation

--- a/docs/plugins/transform-object-rest-spread.md
+++ b/docs/plugins/transform-object-rest-spread.md
@@ -3,6 +3,7 @@ layout: docs
 title: Object rest spread transform
 description:
 permalink: /docs/plugins/transform-object-rest-spread/
+package: babel-plugin-transform-object-rest-spread
 ---
 
 ## Installation

--- a/docs/plugins/transform-object-set-prototype-of-to-assign.md
+++ b/docs/plugins/transform-object-set-prototype-of-to-assign.md
@@ -3,6 +3,7 @@ layout: docs
 title: Object set prototype of to assign transform
 description:
 permalink: /docs/plugins/transform-object-set-prototype-of-to-assign/
+package: babel-plugin-transform-object-set-prototype-of-to-assign
 ---
 
 ## Installation

--- a/docs/plugins/transform-property-literals.md
+++ b/docs/plugins/transform-property-literals.md
@@ -3,6 +3,7 @@ layout: docs
 title: Property literals transform
 description:
 permalink: /docs/plugins/transform-property-literals/
+package: babel-plugin-transform-property-literals
 ---
 
 Turn valid identifier property key literals into identifiers.

--- a/docs/plugins/transform-proto-to-assign.md
+++ b/docs/plugins/transform-proto-to-assign.md
@@ -3,6 +3,7 @@ layout: docs
 title: Proto to assign transform
 description:
 permalink: /docs/plugins/transform-proto-to-assign/
+package: babel-plugin-transform-proto-to-assign
 ---
 
 This plugin will transform all `__proto__` assignments to a method that will do a shallow

--- a/docs/plugins/transform-react-constant-elements.md
+++ b/docs/plugins/transform-react-constant-elements.md
@@ -3,6 +3,7 @@ layout: docs
 title: React constant elements transformer
 description:
 permalink: /docs/plugins/transform-react-constant-elements/
+package: babel-plugin-transform-react-constant-elements
 ---
 
 Hoists element creation to the top level for subtrees that are fully static, which reduces call to `React.createElement` and the resulting allocations. More importantly, it tells React that the subtree hasn't changed so React can completely skip it when reconciling.

--- a/docs/plugins/transform-react-display-name.md
+++ b/docs/plugins/transform-react-display-name.md
@@ -3,6 +3,7 @@ layout: docs
 title: React display name transformer
 description:
 permalink: /docs/plugins/transform-react-display-name/
+package: babel-plugin-transform-react-display-name
 ---
 
 Add `displayName` to `React.createClass` calls

--- a/docs/plugins/transform-react-inline-elements.md
+++ b/docs/plugins/transform-react-inline-elements.md
@@ -3,6 +3,7 @@ layout: docs
 title: React inline elements transform
 description:
 permalink: /docs/plugins/transform-react-inline-elements/
+package: babel-plugin-transform-react-inline-elements
 ---
 
 Converts JSX elements to object literals like `{type: 'div', props: ...}` instead of calls to `React.createElement`.

--- a/docs/plugins/transform-react-jsx-compat.md
+++ b/docs/plugins/transform-react-jsx-compat.md
@@ -3,6 +3,7 @@ layout: docs
 title: React JSX compat transform
 description:
 permalink: /docs/plugins/transform-react-jsx-compat/
+package: babel-plugin-transform-react-jsx-compat
 ---
 
 Output JSX into pre-v0.12 React syntax.

--- a/docs/plugins/transform-react-jsx.md
+++ b/docs/plugins/transform-react-jsx.md
@@ -3,6 +3,7 @@ layout: docs
 title: React JSX transform
 description:
 permalink: /docs/plugins/transform-react-jsx/
+package: babel-plugin-transform-react-jsx
 ---
 
 ## Example

--- a/docs/plugins/transform-regenerator.md
+++ b/docs/plugins/transform-regenerator.md
@@ -3,6 +3,7 @@ layout: docs
 title: Regenerator transform
 description:
 permalink: /docs/plugins/transform-regenerator/
+package: babel-plugin-transform-regenerator
 ---
 
 This plugin uses the [regenerator](https://github.com/facebook/regenerator) module to

--- a/docs/plugins/transform-remove-console.md
+++ b/docs/plugins/transform-remove-console.md
@@ -3,6 +3,7 @@ layout: docs
 title: Remove console transform
 description:
 permalink: /docs/plugins/transform-remove-console/
+package: babel-plugin-transform-remove-console
 ---
 
 This plugin removes all `console.*` calls.

--- a/docs/plugins/transform-remove-debugger.md
+++ b/docs/plugins/transform-remove-debugger.md
@@ -3,6 +3,7 @@ layout: docs
 title: Remove debugger transform
 description:
 permalink: /docs/plugins/transform-remove-debugger/
+package: babel-plugin-transform-remove-debugger
 ---
 
 This plugin removes all `debugger;` statements.

--- a/docs/plugins/transform-runtime.md
+++ b/docs/plugins/transform-runtime.md
@@ -3,6 +3,7 @@ layout: docs
 title: Runtime transform
 description:
 permalink: /docs/plugins/transform-runtime/
+package: babel-plugin-transform-runtime
 ---
 
 ## Installation

--- a/docs/plugins/transform-simplify-comparison-operators.md
+++ b/docs/plugins/transform-simplify-comparison-operators.md
@@ -3,6 +3,7 @@ layout: docs
 title: Simplfy comparison operator transform
 description:
 permalink: /docs/plugins/transform-simplify-comparison-operators/
+package: babel-plugin-transform-simplify-comparison-operators
 ---
 
 This plugin simplifies comparisons from strict `===` to `==` when each side is inferred

--- a/docs/plugins/transform-strict-mode.md
+++ b/docs/plugins/transform-strict-mode.md
@@ -3,6 +3,7 @@ layout: docs
 title: Strict mode transform
 description:
 permalink: /docs/plugins/transform-strict-mode/
+package: babel-plugin-transform-strict-mode
 ---
 
 This plugin places a `"use strict";` directive at the top of all files to enable

--- a/docs/plugins/transform-undefined-to-void.md
+++ b/docs/plugins/transform-undefined-to-void.md
@@ -3,6 +3,7 @@ layout: docs
 title: Undefined to void transform
 description:
 permalink: /docs/plugins/transform-undefined-to-void/
+package: babel-plugin-transform-undefined-to-void
 ---
 
 Some JavaScript implementations allow undefined to be overwritten, this may lead to peculiar bugs that are extremely hard to track down.

--- a/docs/plugins/undeclared-variables-check.md
+++ b/docs/plugins/undeclared-variables-check.md
@@ -3,6 +3,7 @@ layout: docs
 title: Undeclared variables check
 description:
 permalink: /docs/plugins/undeclared-variables-check/
+package: babel-plugin-undeclared-variables-check
 ---
 
 This plugin throws errors on references to undeclared variables.


### PR DESCRIPTION
See #508.

I've added a `package` property that can be set in the front matter of any docs page, for specifying the name of the relevant npm package (if any).

In the layout this property is used to add GitHub and npm links in the header.

How this looks on a page with a description:

![image](https://cloud.githubusercontent.com/assets/250617/10871914/4b114cb6-80ed-11e5-8653-7a8c425ba165.png)

How it looks on other pages:

![image](https://cloud.githubusercontent.com/assets/250617/10871911/39bc35f2-80ed-11e5-8251-ac007b926f6b.png)
