### PR TITLE
Add link to blog post about function bind syntax

### DIFF
--- a/docs/plugins/transform-class-properties.md
+++ b/docs/plugins/transform-class-properties.md
@@ -21,3 +21,7 @@ Add the following line to your `.babelrc` file:
   "plugins": ["transform-class-properties"]
 }
 ```
+
+## References
+
+* [Proposal: ES Class Fields & Static Properties](https://github.com/jeffmo/es-class-static-properties-and-fields)

--- a/docs/plugins/transform-decorators.md
+++ b/docs/plugins/transform-decorators.md
@@ -21,3 +21,7 @@ Add the following line to your `.babelrc` file:
   "plugins": ["transform-decorators"]
 }
 ```
+
+## References
+
+* [Proposal: Javascript Decorators](https://github.com/wycats/javascript-decorators/blob/master/README.md)

--- a/docs/plugins/transform-exponentiation-operator.md
+++ b/docs/plugins/transform-exponentiation-operator.md
@@ -21,3 +21,8 @@ Add the following line to your `.babelrc` file:
   "plugins": ["transform-exponentiation-operator"]
 }
 ```
+
+## References
+
+* [Proposal: Exponentiation Operator](https://github.com/rwaldron/exponentiation-operator)
+* [Spec: Exponential Operator](http://rwaldron.github.io/exponentiation-operator/)

--- a/docs/plugins/transform-export-extensions.md
+++ b/docs/plugins/transform-export-extensions.md
@@ -21,3 +21,7 @@ Add the following line to your `.babelrc` file:
   "plugins": ["transform-export-extensions"]
 }
 ```
+
+## References
+
+* [Proposal: Additional export-from statements in ES7](https://github.com/leebyron/ecmascript-more-export-from)

--- a/docs/plugins/transform-function-bind.md
+++ b/docs/plugins/transform-function-bind.md
@@ -21,3 +21,7 @@ Add the following line to your `.babelrc` file:
   "plugins": ["transform-function-bind"]
 }
 ```
+
+## References
+
+* [Babel Blog: Function Bind Syntax](/blog/2015/05/14/function-bind/)

--- a/docs/plugins/transform-object-rest-spread.md
+++ b/docs/plugins/transform-object-rest-spread.md
@@ -21,3 +21,7 @@ Add the following line to your `.babelrc` file:
   "plugins": ["transform-object-rest-spread"]
 }
 ```
+
+## References
+
+* [Proposal: Object Rest/Spread Properties for ECMAScript](https://github.com/sebmarkbage/ecmascript-rest-spread)


### PR DESCRIPTION
I was having a difficult time figuring out what features some plugins add. I think a "Learn more" section with either a code example or a link would be helpful so people can read more about the feature. Would it be okay if I start adding this section to a few of the plugin's documentation that I know about?