### PR TITLE
Add mention of ReactJS.NET

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -14,6 +14,7 @@
     gulp: Gulp
     jspm: jspm
     make: Make
+    msbuild: MSBuild
     requirejs: RequireJS
     rollup: Rollup
     sprockets: Sprockets
@@ -37,6 +38,7 @@
     nodemon: Nodemon
 - name: Language APIs
   items:
+    dotnet: C# / .NET
     node: Node
     ruby: Ruby
 - name: Template engines

--- a/_includes/tools/dotnet/install.md
+++ b/_includes/tools/dotnet/install.md
@@ -1,0 +1,5 @@
+Support for Babel in .NET is provided by the [ReactJS.NET](http://reactjs.net/) project. The core library can be installed via NuGet:
+
+```
+Install-Package React.Core
+```

--- a/_includes/tools/dotnet/usage.md
+++ b/_includes/tools/dotnet/usage.md
@@ -1,0 +1,9 @@
+```csharp
+var babel = ReactEnvironment.Current.Babel;
+// Transpiles a file
+// You can instead use `TransformFileWithSourceMap` if you want a source map too.
+var result = babel.TransformFile("foo.js");
+// Transpiles a piece of code
+var result = babel.Transform("class Foo { }");
+
+```

--- a/_includes/tools/msbuild/install.md
+++ b/_includes/tools/msbuild/install.md
@@ -1,0 +1,5 @@
+Support for Babel in .NET is provided by the [ReactJS.NET](http://reactjs.net/) project. Install the MSBuild task via NuGet:
+
+```
+Install-Package React.MSBuild
+```

--- a/_includes/tools/msbuild/usage.md
+++ b/_includes/tools/msbuild/usage.md
@@ -1,0 +1,15 @@
+Import the task in your MSBuild script:
+
+```xml
+<UsingTask AssemblyFile="packages\React.MSBuild.2.1.0\React.MSBuild.dll" TaskName="TransformBabel" />
+```
+
+Use it:
+
+```xml
+<TransformBabel SourceDir="$(MSBuildProjectDirectory)" TargetDir="" />
+```
+
+This will transform every `.js` and `.jsx` file in the directory, and output a `.generated.js` file alongside it.
+
+See http://reactjs.net/guides/msbuild.html for more information


### PR DESCRIPTION
Add mention of ReactJS.NET for C# and MSBuild support. Eventually I'd like to split ReactJS.NET into a smaller project that isn't actually explicitly for React, but this will do for now. This part of ReactJS.NET isn't actually specific to React in any way, it's just wrapping Babel in the V8 or Chakra/MSIE engine (similar to the Ruby integration)