### PR TITLE
Fix "ES2015 Preset" Link

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@ myNewTransformedJavaScript("yay!");
   <div class="row featurette">
     <div class="col-md-6">
       <h2>ES2015 and beyond</h2>
-      <p>Babel has support for the latest version of JavaScript through syntax transformers. These allow you to use new syntax, <strong>right now</strong> without waiting for browser support. Check out our [ES2015 preset](http://babeljs.io/docs/plugins/preset-es2015/) to get started. <a href="/docs/learn-es2015/">Learn about ES2015 &rarr;</a></p>
+      <p>Babel has support for the latest version of JavaScript through syntax transformers. These allow you to use new syntax, <strong>right now</strong> without waiting for browser support. Check out our <a href="http://babeljs.io/docs/plugins/preset-es2015">ES2015 preset</a> to get started. <a href="/docs/learn-es2015/">Learn about ES2015 &rarr;</a></p>
     </div>
 
     <div class="col-md-6">


### PR DESCRIPTION
Link was originally in Markdown syntax.