### PR TITLE
Move the "no default transformations in v6" note to the usage section.

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -37,6 +37,13 @@ custom_js_with_timestamps:
 
       {% include tools/items.md name="usage" %}
 
+      <blockquote class="babel-callout babel-callout-info">
+        <h4>Note</h4>
+        <p>
+          Pre-6.x, Babel enabled certain transformations by default. However, Babel 6.x <i>does not</i> ship with any transformations enabled. You need to explicitly tell it what transformations to run. The simplest way to do this is by using a <a href="http://babeljs.io/docs/plugins/#presets">preset</a>, such as the <a href="https://babeljs.io/docs/plugins/preset-es2015/">ES2015 Preset</a>.
+        </p>
+      </blockquote>
+
       <blockquote class="babel-callout babel-callout-warning">
         <h4>Warning!</h4>
         <p>
@@ -50,12 +57,6 @@ custom_js_with_timestamps:
 
       <p>Great! You've configured Babel but you haven't made it actually <em>do</em> anything. Create a <a href="/docs/usage/babelrc">.babelrc</a> config in your project root and enable some <a href="/docs/plugins">plugins</a>.</p>
       
-      <blockquote class="babel-callout babel-callout-info">
-        <h4>Note</h4>
-        <p>
-          Pre-6.x, Babel enabled certain transformations by default. However, Babel 6.x <i>does not</i> ship with any transformations enabled. You need to explicitly tell it what transformations to run. The simplest way to do this is by using a <a href="http://babeljs.io/docs/plugins/#presets">preset</a>, such as the <a href="https://babeljs.io/docs/plugins/preset-es2015/">ES2015 Preset</a>.
-        </p>
-      </blockquote>
     </div>
   </div>
 </div>


### PR DESCRIPTION
See https://phabricator.babeljs.io/T6711

tl;dr: I'm trying out Babel and wanted to set up a one shot shell session. I thus skipped the `.babelrc` section (no need for a permanent config file at this point) and ended up surprised that vanilla Babel is just a JS syntax validator.

Update: accidently a whole word (still absent in the commit message title, hopefully you won't mind).