### PR TITLE
 	Add a note about the lack of transformations in v6, give a presets example.

### DIFF
--- a/docs/plugins/preset-es2015.md
+++ b/docs/plugins/preset-es2015.md
@@ -37,7 +37,7 @@ $ npm install babel-preset-es2015
 
 ## Usage
 
-Add the following line to your `.babelrc` file:
+Pass `--presets es2015` as a command line option or add the following line to your `.babelrc` file:
 
 ```json
 {

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -20,6 +20,14 @@ available from the command line.
 $ npm install --global babel-cli
 ```
 
+Out of the box, Babel (since v6) doesn't perform any transformation, it only validates the syntax. You may want to install [plugins](/docs/plugins) or more likely whole [presets](/docs/plugins/#presets) before going further. For the sake of the example, we'll use the [es2015](/docs/plugins/preset-es2015/) preset.
+
+```sh
+$ npm install babel-preset-es2015
+```
+
+For Babel to use the preset you must either pass it in the command line as `--presets es2015` (omitted in the rest of the page for readability) or add it to the [`.babelrc`](/docs/usage/babelrc/) file, in the `"presets"` section.
+
 ## babel
 
 #### Compile Files


### PR DESCRIPTION
Sorry for the initially blank message, I hit return instead of backspace while editing the title... So:

See https://phabricator.babeljs.io/T6711

In their current state, the docs are not very helpful for newcomers.

The only mention of the lack of transformations post v6 is in the `.babelrc` section, and you must navigate too many pages to get Babel to perform what you'd expect it to do (i.e. more than syntax validation).

This may make #609 superfluous.
