### PR TITLE
Fix documentation to not install babel-cli globally

### DIFF
--- a/_includes/tools/babel_cli/install.md
+++ b/_includes/tools/babel_cli/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install -g babel-cli
+$ npm install babel-cli
 ```

--- a/_includes/tools/babel_cli/install.md
+++ b/_includes/tools/babel_cli/install.md
@@ -1,3 +1,30 @@
+While you _can_ install Babel CLI globally on your machine, it's much better
+to install it **locally** project by project.
+
+There are two primary reasons for this.
+
+  1. Different projects on the same machine can depend on different versions of
+     Babel allowing you to update one at a time.
+  2. It means you do not have an implicit dependency on the environment you are
+     working in. Making your project far more portable and easier to setup.
+
+We can install Babel CLI locally by running:
+
 ```sh
-$ npm install babel-cli
+$ npm install --save-dev babel-cli
+```
+
+> **Note:** Since it's generally a bad idea to run Babel globally you may want
+> to uninstall the global copy by running `npm uninstall --global babel-cli`.
+
+After that finishes installing, your `package.json` file should look like this:
+
+```json
+{
+  "name": "my-project",
+  "version": "1.0.0",
+  "devDependencies": {
+    "babel-cli": "^6.0.0"
+  }
+}
 ```

--- a/_includes/tools/babel_cli/usage.md
+++ b/_includes/tools/babel_cli/usage.md
@@ -1,6 +1,30 @@
-```sh
-$ babel script.js
+Instead of running Babel directly from the command line we're going to put
+our commands in **npm scripts** which will use our local version.
+
+Simply add a `"scripts"` field to your `package.json` and put the babel command
+inside there as `build`.
+
+```diff
+  {
+    "name": "my-project",
+    "version": "1.0.0",
++   "scripts": {
++     "build": "babel src -d lib"
++   },
+    "devDependencies": {
+      "babel-cli": "^6.0.0"
+    }
+  }
 ```
+
+Now from our terminal we can run:
+
+```js
+npm run build
+```
+
+This will run Babel the same way as before and the output will be
+present in `lib` directory, only now we are using a local copy.
 
 <blockquote class="babel-callout babel-callout-info">
   <p>

--- a/_includes/tools/webstorm/install.md
+++ b/_includes/tools/webstorm/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install babel-cli
+$ npm install --save-dev babel-cli
 ```

--- a/_includes/tools/webstorm/install.md
+++ b/_includes/tools/webstorm/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install -g babel-cli
+$ npm install babel-cli
 ```

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -14,12 +14,7 @@ package: babel-cli
 
 ## Installation
 
-Using [npm](https://www.npmjs.com/) you can install Babel globally, making it
-available from the command line.
-
-```sh
-$ npm install --global babel-cli
-```
+{% include tools/babel_cli/install.md %}
 
 ## babel
 


### PR DESCRIPTION
- Followup of https://github.com/babel/babel/pull/3150
- Fixes https://github.com/babel/babel.github.io/issues/632