### PR TITLE
Add note in docs for importing babel-polyfill with ES6 import syntax

### DIFF
--- a/docs/usage/polyfill.md
+++ b/docs/usage/polyfill.md
@@ -30,6 +30,13 @@ to your application.
 require("babel-polyfill");
 ```
 
+If you are using ES6's `import` syntax in your application's **entry point**, you
+should instead import the polyfill at the top of the **entry point** to ensure the
+polyfills are loaded first:
+```javascript
+import polyfill from "babel-polyfill";
+```
+
 ## Usage in Browser
 
 Available from the `dist/polyfill.js` file within a `babel-polyfill` npm release.

--- a/docs/usage/polyfill.md
+++ b/docs/usage/polyfill.md
@@ -34,7 +34,7 @@ If you are using ES6's `import` syntax in your application's **entry point**, yo
 should instead import the polyfill at the top of the **entry point** to ensure the
 polyfills are loaded first:
 ```javascript
-import polyfill from "babel-polyfill";
+import "babel-polyfill";
 ```
 
 ## Usage in Browser


### PR DESCRIPTION
Currently, the docs suggest the user to just use `require("babel-polyfill");` at the top of the entry point into their application. This can lead to confusion and difficult to debug bugs with the polyfill not being loaded if the entry point later uses ESE6's `import` syntax to load other app dependencies.

Because `import`s are hoisted to the top of the file, having an application entry point that looks like this:
```javascript
require("babel-polyfill");

// routes uses polyfilled features in definition (such as creating Sets, etc)
import routes from 'routes';

...
```

would cause the `import` statement to be hoisted above the `require` statement and cause errors in `routes.js`.