### PR TITLE
add will-change property to sticky header

### DIFF
--- a/_sass/bootstrap/_navbar.scss
+++ b/_sass/bootstrap/_navbar.scss
@@ -141,6 +141,7 @@
   position: fixed;
   right: 0;
   left: 0;
+  will-change: transform;
   z-index: $zindex-navbar-fixed;
 
   // Undo the rounded corners


### PR DESCRIPTION
Position: fixed adds a lot of repaint on scroll to the page. Adding `will-change: transform` will promote it to it's own layer.

![babel-sticky-header](https://cloud.githubusercontent.com/assets/5244986/11840716/42dcf8a0-a3f8-11e5-90d8-5518ad62f2bb.png)
