### PR TITLE
Remove invalid Babel6 option

### DIFF
--- a/docs/usage/options.md
+++ b/docs/usage/options.md
@@ -38,7 +38,6 @@ $ babel --name=value
 | `moduleId`               | `null`               | Specify a custom name for module ids. |
 | `getModuleId`            | `null`               | Specify a custom callback to generate a module id with. Called as `getModuleId(moduleName)`. If falsy value is returned then the generated module id is used. |
 | `resolveModuleSource`    | `null`               | Resolve a module source ie. `import "SOURCE";` to a custom value. Called as `resolveModuleSource(source, filename)`. |
-| `keepModuleIdExtensions` | `false`              | Keep extensions in module ids |
 | `code`                   | `true`               | Enable code generation |
 | `babelrc`                | `true`               | Specify whether or not to use .babelrc and .babelignore files. |
 | `ast`                    | `true`               | Include the AST in the returned object |


### PR DESCRIPTION
This option doesn't exist in Babel@6:
https://github.com/babel/babel/blob/master/packages/babel-core/src/transformation/file/options/config.js

This PR is to add that feature back but until it is merged and released the docs should be corrected. Ideally this could be merged right away and that PR can add the doc back when it is released.
https://github.com/babel/babel/pull/3155