### PR TITLE
Fix rendering bug on babeljs.io website

### DIFF
--- a/docs/usage/polyfill.md
+++ b/docs/usage/polyfill.md
@@ -33,6 +33,7 @@ require("babel-polyfill");
 If you are using ES6's `import` syntax in your application's **entry point**, you
 should instead import the polyfill at the top of the **entry point** to ensure the
 polyfills are loaded first:
+
 ```javascript
 import "babel-polyfill";
 ```


### PR DESCRIPTION
Currently https://babeljs.io/docs/usage/polyfill/ says 'ensure the polyfills are loaded first: javascript import "babel-polyfill";' in one line.