### PR TITLE
Renamed babel-plugin-external-helpers-2 to babel-plugin-external-helpers

### DIFF
--- a/docs/plugins/external-helpers.md
+++ b/docs/plugins/external-helpers.md
@@ -9,7 +9,7 @@ package: babel-plugin-external-helpers-2
 ## Installation
 
 ```sh
-$ npm install babel-plugin-external-helpers-2
+$ npm install babel-plugin-external-helpers
 ```
 
 ## Usage
@@ -18,6 +18,6 @@ Add the following line to your `.babelrc` file:
 
 ```json
 {
-  "plugins": ["external-helpers-2"]
+  "plugins": ["external-helpers"]
 }
 ```


### PR DESCRIPTION
Ref - https://github.com/babel/babel/pull/3205
- Fixes #658