### PR TITLE
Warn users that npm >= 3.3.0 is required to use babel 6.x

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -57,7 +57,11 @@ custom_js_with_timestamps:
 
       <p>Great! You've configured Babel but you haven't made it actually <em>do</em> anything. Create a <a href="/docs/usage/babelrc">.babelrc</a> config in your project root and enable some <a href="/docs/plugins">plugins</a>.</p>
       <p>Assuming you installed the <a href="https://babeljs.io/docs/plugins/preset-es2015/">ES2015 Preset</a>, you can do this with <pre>echo '{ "presets": ["es2015"] }' > .babelrc</pre></p>
-      
+
     </div>
+
+    <p>
+      <strong>Note</strong>: Running a Babel 6.x project using npm 2.x can cause performance problems because of the way npm 2.x installs dependencies. This problem can be eliminated by either switching to npm 3.x or running npm 2.x with the <a href="https://docs.npmjs.com/cli/dedupe">dedupe</a> flag. To check what version of npm you have run <pre>npm --version</pre>
+    <p>
   </div>
 </div>


### PR DESCRIPTION
Babel 6's new tool `babel-doctor` [requires users to be using npm >= 3.3](https://github.com/babel/babel/blob/e75f2ef5bb340e71ec413709eaa1311beed2a834/packages/babel-cli/src/babel-doctor/rules/npm-3.js). It is not clear in any docs or blog posts whether or not Babel has officially dropped support for npm 2.x but if this is true it should be very prominently displayed in the docs.

Thanks for all the great work!

