### PR TITLE
Documentation for babel-plugin-transform-runtime

### DIFF
--- a/docs/plugins/transform-runtime.md
+++ b/docs/plugins/transform-runtime.md
@@ -6,6 +6,8 @@ permalink: /docs/plugins/transform-runtime/
 package: babel-plugin-transform-runtime
 ---
 
+# babel-plugin-transform-runtime
+
 Externalise references to helpers and builtins, automatically polyfilling your code without polluting globals.
 
 ## Why?
@@ -14,9 +16,9 @@ Babel uses very small helpers for common functions such as `_extend`. By default
 
 This is where the runtime transformer plugin comes in: all of the helpers will reference the module babel-runtime to avoid duplication across your compiled output. The runtime will be compiled into your build.
 
-Another purpose of this transformer is to create a sandboxed environment for your code. Built-ins such as `Promise`, `Set` and `Map` are aliased to `core-js` so you can use them seamlessly without having to require a globally polluting [polyfill](https://babeljs.io/docs/usage/polyfill/).
+Another purpose of this transformer is to create a sandboxed environment for your code. If you use [babel-polyfill](https://github.com/contentful/contentful-space-sync/releases/tag/v3.0.0) and the built-ins it provides such as `Promise`, `Set` and `Map`, those will pollute the global scope. While this might be ok for an app or a command line tool, it becomes a problem if your code is a library which you intend to publish for others to use or if you can't exactly control the environment in which your code will run.
 
-This is specially useful for libraries as you can write your code without the cognitive overhead of worrying about the environment in which your code will be run, as you are not including a polyfill which can override existing globals.
+The transformer will alias these built-ins to `core-js` so you can use them seamlessly without having to require the polyfill.
 
 See the technical details section for more information on how this works and the types of transformations that occur.
 
@@ -25,6 +27,10 @@ See the technical details section for more information on how this works and the
 ```sh
 $ npm install babel-plugin-transform-runtime
 ```
+
+It is also recommended you install the `babel-runtime` package as a
+runtime dependency, if you haven't already, as the transformed code will
+require that package. See the examples below for more details.
 
 ## Usage
 
@@ -61,6 +67,8 @@ The `runtime` transformer plugin does three things:
 * Removes the inline babel helpers and uses the module `babel-runtime/helpers` instead.
 
 What does this actually mean though? Basically, you can use built-ins such as `Promise`, `Set`, `Symbol` etc as well use all the Babel features that require a polyfill seamlessly, without global pollution, making it extremely suitable for libraries.
+
+Make sure you include `babel-runtime` as a dependency.
 
 ### Regenerator aliasing
 

--- a/docs/plugins/transform-runtime.md
+++ b/docs/plugins/transform-runtime.md
@@ -16,7 +16,7 @@ Babel uses very small helpers for common functions such as `_extend`. By default
 
 This is where the runtime transformer plugin comes in: all of the helpers will reference the module babel-runtime to avoid duplication across your compiled output. The runtime will be compiled into your build.
 
-Another purpose of this transformer is to create a sandboxed environment for your code. If you use [babel-polyfill](https://github.com/contentful/contentful-space-sync/releases/tag/v3.0.0) and the built-ins it provides such as `Promise`, `Set` and `Map`, those will pollute the global scope. While this might be ok for an app or a command line tool, it becomes a problem if your code is a library which you intend to publish for others to use or if you can't exactly control the environment in which your code will run.
+Another purpose of this transformer is to create a sandboxed environment for your code. If you use [babel-polyfill](https://babeljs.io/docs/usage/polyfill/) and the built-ins it provides such as `Promise`, `Set` and `Map`, those will pollute the global scope. While this might be ok for an app or a command line tool, it becomes a problem if your code is a library which you intend to publish for others to use or if you can't exactly control the environment in which your code will run.
 
 The transformer will alias these built-ins to `core-js` so you can use them seamlessly without having to require the polyfill.
 

--- a/docs/plugins/transform-runtime.md
+++ b/docs/plugins/transform-runtime.md
@@ -6,6 +6,20 @@ permalink: /docs/plugins/transform-runtime/
 package: babel-plugin-transform-runtime
 ---
 
+Externalise references to helpers and builtins, automatically polyfilling your code without polluting globals.
+
+## Why?
+
+Babel uses very small helpers for common functions such as `_extend`. By default this will be added to every file that requires it. This duplication is sometimes unnecessary, especially when your application is spread out over multiple files.
+
+This is where the runtime transformer plugin comes in: all of the helpers will reference the module babel-runtime to avoid duplication across your compiled output. The runtime will be compiled into your build.
+
+Another purpose of this transformer is to create a sandboxed environment for your code. Built-ins such as `Promise`, `Set` and `Map` are aliased to `core-js` so you can use them seamlessly without having to require a globally polluting [polyfill](https://babeljs.io/docs/usage/polyfill/).
+
+This is specially useful for libraries as you can write your code without the cognitive overhead of worrying about the environment in which your code will be run, as you are not including a polyfill which can override existing globals.
+
+See the technical details section for more information on how this works and the types of transformations that occur.
+
 ## Installation
 
 ```sh
@@ -14,10 +28,158 @@ $ npm install babel-plugin-transform-runtime
 
 ## Usage
 
+### Via `.babelrc` (Recommended)
+
 Add the following line to your `.babelrc` file:
 
 ```json
 {
   "plugins": ["transform-runtime"]
 }
+```
+
+### Via CLI
+
+```sh
+$ babel --plugins transform-runtime script.js
+```
+
+### Via Node API
+
+```javascript
+require("babel-core").transform("code", {
+  plugins: ["transform-runtime"]
+});
+```
+
+## Technical details
+
+The `runtime` transformer plugin does three things:
+
+* Automatically requires `babel-runtime/regenerator` when you use generators/async functions.
+* Automatically requires `babel-runtime/core-js` and maps ES6 static methods and built-ins.
+* Removes the inline babel helpers and uses the module `babel-runtime/helpers` instead.
+
+What does this actually mean though? Basically, you can use built-ins such as `Promise`, `Set`, `Symbol` etc as well use all the Babel features that require a polyfill seamlessly, without global pollution, making it extremely suitable for libraries.
+
+### Regenerator aliasing
+
+Whenever you use a generator function or async function:
+
+```javascript
+function* foo() {
+
+}
+
+async function bar() {
+
+}
+```
+
+the following is generated:
+
+```javascript
+"use strict";
+
+var foo = regeneratorRuntime.mark(function foo() {
+  ...
+});
+
+function bar() {
+  return regeneratorRuntime.async(function bar$(context$1$0) {
+    ...
+  }, null, this);
+}
+```
+
+This isn't ideal as then you have to include the regenerator runtime which
+pollutes the global scope.
+
+Instead what the `runtime` transformer does it compile that to:
+
+```javascript
+"use strict";
+
+var _regeneratorRuntime = require("babel-runtime/regenerator");
+
+var foo = _regeneratorRuntime.mark(function foo() {
+  ...
+});
+
+function bar() {
+  return _regeneratorRuntime.async(function bar$(context$1$0) {
+    ...
+  }, null, this);
+}
+```
+
+This means that you can use the regenerator runtime without polluting your current environment.
+
+### `core-js` aliasing
+
+Sometimes you may want to use new built-ins such as `Map`, `Set`, `Promise` etc. Your only way
+to use these is usually to include a globally polluting polyfill.
+
+What the `runtime` transformer does is transform the following:
+
+```javascript
+var sym = Symbol();
+
+var promise = new Promise;
+
+console.log(arr[Symbol.iterator]());
+```
+
+into the following:
+
+```javascript
+"use strict";
+
+var _core = require("babel-runtime/core-js");
+
+var sym = _core.Symbol();
+
+var promise = new _core.Promise();
+
+console.log(_core.$for.getIterator(arr));
+```
+
+This means is that you can seamlessly use these native built-ins and static methods
+without worrying about where they come from.
+
+**NOTE:** Instance methods such as `"foobar".includes("foo")` will **not** work.
+
+### Helper aliasing
+
+Usually babel will place helpers at the top of your file to do common tasks to avoid
+duplicating the code around in the current file. Sometimes these helpers can get a
+little bulky and add unnecessary duplication across files. The `runtime`
+transformer replaces all the helper calls to a module.
+
+That means that the following code:
+
+```javascript
+import foo from "bar";
+```
+
+usually turns into:
+
+```javascript
+"use strict";
+
+var _interopRequire = function (obj) {
+  return obj && obj.__esModule ? obj["default"] : obj;
+};
+
+var foo = _interopRequire(require("bar"));
+```
+
+the `runtime` transformer however turns this into:
+
+```javascript
+"use strict";
+
+var _babelHelpers = require("babel-runtime/helpers");
+
+var foo = _babelHelpers.interopRequire(require("bar"));
 ```

--- a/docs/plugins/transform-runtime.md
+++ b/docs/plugins/transform-runtime.md
@@ -70,10 +70,6 @@ Whenever you use a generator function or async function:
 function* foo() {
 
 }
-
-async function bar() {
-
-}
 ```
 
 the following is generated:
@@ -81,14 +77,16 @@ the following is generated:
 ```javascript
 "use strict";
 
-var foo = regeneratorRuntime.mark(function foo() {
-  ...
-});
+var _marked = [foo].map(regeneratorRuntime.mark);
 
-function bar() {
-  return regeneratorRuntime.async(function bar$(context$1$0) {
-    ...
-  }, null, this);
+function foo() {
+  return regeneratorRuntime.wrap(function foo$(_context) {
+    while (1) switch (_context.prev = _context.next) {
+      case 0:
+      case "end":
+        return _context.stop();
+    }
+  }, _marked[0], this);
 }
 ```
 
@@ -100,16 +98,22 @@ Instead what the `runtime` transformer does it compile that to:
 ```javascript
 "use strict";
 
-var _regeneratorRuntime = require("babel-runtime/regenerator");
+var _regenerator = require("babel-runtime/regenerator");
 
-var foo = _regeneratorRuntime.mark(function foo() {
-  ...
-});
+var _regenerator2 = _interopRequireDefault(_regenerator);
 
-function bar() {
-  return _regeneratorRuntime.async(function bar$(context$1$0) {
-    ...
-  }, null, this);
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var _marked = [foo].map(_regenerator2.default.mark);
+
+function foo() {
+  return regeneratorRuntime.wrap(function foo$(_context) {
+    while (1) switch (_context.prev = _context.next) {
+      case 0:
+      case "end":
+        return _context.stop();
+    }
+  }, _marked[0], this);
 }
 ```
 
@@ -135,13 +139,25 @@ into the following:
 ```javascript
 "use strict";
 
-var _core = require("babel-runtime/core-js");
+var _getIterator2 = require("babel-runtime/core-js/get-iterator");
 
-var sym = _core.Symbol();
+var _getIterator3 = _interopRequireDefault(_getIterator2);
 
-var promise = new _core.Promise();
+var _promise = require("babel-runtime/core-js/promise");
 
-console.log(_core.$for.getIterator(arr));
+var _promise2 = _interopRequireDefault(_promise);
+
+var _symbol = require("babel-runtime/core-js/symbol");
+
+var _symbol2 = _interopRequireDefault(_symbol);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var sym = (0, _symbol2.default)();
+
+var promise = new _promise2.default();
+
+console.log((0, _getIterator3.default)(arr));
 ```
 
 This means is that you can seamlessly use these native built-ins and static methods
@@ -159,7 +175,8 @@ transformer replaces all the helper calls to a module.
 That means that the following code:
 
 ```javascript
-import foo from "bar";
+class Person {
+}
 ```
 
 usually turns into:
@@ -167,11 +184,11 @@ usually turns into:
 ```javascript
 "use strict";
 
-var _interopRequire = function (obj) {
-  return obj && obj.__esModule ? obj["default"] : obj;
-};
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-var foo = _interopRequire(require("bar"));
+var Person = function Person() {
+  _classCallCheck(this, Person);
+};
 ```
 
 the `runtime` transformer however turns this into:
@@ -179,7 +196,13 @@ the `runtime` transformer however turns this into:
 ```javascript
 "use strict";
 
-var _babelHelpers = require("babel-runtime/helpers");
+var _classCallCheck2 = require("babel-runtime/helpers/classCallCheck");
 
-var foo = _babelHelpers.interopRequire(require("bar"));
+var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var Person = function Person() {
+  (0, _classCallCheck3.default)(this, Person);
+};
 ```


### PR DESCRIPTION
Based on https://github.com/babel/babel.github.io/blob/862b43db93e48762671267034a50c30c00e433e2/docs/usage/runtime.md

Not sure if the documentation from Babel 5 is still 100% accurate, but from what I could understand it seems to be.

Related to https://github.com/babel/babel.github.io/issues/674 and https://github.com/babel/babel.github.io/issues/491

Also added this to the main repo at https://github.com/babel/babel/pull/3258