### PR TITLE
Get rid of REPL keyboard hijacking annoyances.

### DIFF
--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -87,6 +87,7 @@
 
     this.editor.setTheme('ace/theme/tomorrow');
     this.editor.setShowPrintMargin(false);
+    this.editor.commands.removeCommands(['gotoline', 'find']);
     this.$el.css({
       fontFamily: 'Menlo, Monaco, Consolas, "Courier New", monospace',
       lineHeight: 'inherit'


### PR DESCRIPTION
I use the Babel REPL website a lot, and I also use <kbd>⌘</kbd> + <kbd>L</kbd> a lot to focus the browser address bar. In the Babel REPL site I can't because the editor hijacks this shortcut, as well as the browser Find command under <kbd>⌘</kbd> + <kbd>F</kbd>.

Neither of these features make sense for a REPL that's most typically used to play around with small snippets of code.