### PR TITLE
Fix math in Modules example

### DIFF
--- a/docs/learn-es6.md
+++ b/docs/learn-es6.md
@@ -414,7 +414,7 @@ export default function(x) {
 ```js
 // app.js
 import exp, {pi, e} from "lib/mathplusplus";
-alert("2π = " + exp(pi, e));
+alert("e^π = " + exp(pi));
 ```
 
 <blockquote class="babel-callout babel-callout-info">


### PR DESCRIPTION
This line: 

```js
alert("2π = " + exp(pi, e));
```
* Result = `23.14070064895278` == e^π
* `2π`  should be `e^π`
* `exp` expects only one argument



