### PR TITLE
Object.assign example Point -> shape

### DIFF
--- a/docs/learn-es6.md
+++ b/docs/learn-es6.md
@@ -680,7 +680,7 @@ Array.of(1, 2, 3) // Similar to new Array(...), but without special one-arg beha
 ["a", "b", "c"].keys() // iterator 0, 1, 2
 ["a", "b", "c"].values() // iterator "a", "b", "c"
 
-Object.assign(Point, { origin: new Point(0,0) })
+Object.assign(shape, { origin: new Point(0,0) })
 ```
 
 <blockquote class="babel-callout babel-callout-warning">


### PR DESCRIPTION
Shouldn't `Point ` be a `shape` or a `rect` or something? And with a lowercase letter? 
Or am I missing the point (pun not intended, haha) here? 