### PR TITLE
Added Destructuring + default arguments example

### DIFF
--- a/docs/learn-es6.md
+++ b/docs/learn-es6.md
@@ -193,6 +193,12 @@ a === undefined;
 // Fail-soft destructuring with defaults
 var [a = 1] = [];
 a === 1;
+
+// Destructuring + defaults arguments
+function r({x, y, w = 10, h = 10}) {
+  return x + y + w + h;
+}
+r({x:1, y:2}) === 23
 ```
 
 ### Default + Rest + Spread


### PR DESCRIPTION
Someone showed me [an example](https://docs.google.com/presentation/d/1uYY4UzjU8QAojLylGod2JUp691JaXGqSCgtQYRnxfGE/edit#slide=id.ged7eaf7f0_0_131) of this but couldn't find it in the docs. Turned out to be invalid syntax.. 

An example might be nice. 