### PR TITLE
Fix external helpers plugin package link

### DIFF
--- a/docs/plugins/external-helpers.md
+++ b/docs/plugins/external-helpers.md
@@ -3,7 +3,7 @@ layout: docs
 title: External helpers
 description:
 permalink: /docs/plugins/external-helpers/
-package: babel-plugin-external-helpers-2
+package: babel-plugin-external-helpers
 ---
 
 ## Installation


### PR DESCRIPTION
This fixes missing Github link and leads to the correct and newest external helpers plugin in npm.