### PR TITLE
Update react preset doc to include displayName transform

### DIFF
--- a/docs/plugins/preset-react.md
+++ b/docs/plugins/preset-react.md
@@ -12,6 +12,7 @@ This preset includes the following plugins:
 - [syntax-jsx](/docs/plugins/syntax-jsx)
 - [transform-flow-strip-types](/docs/plugins/transform-flow-strip-types)
 - [transform-react-jsx](/docs/plugins/transform-react-jsx)
+- [transform-react-display-name](/docs/plugins/transform-react-display-name)
 
 ## Installation
 


### PR DESCRIPTION
The react preset [includes babel-plugin-transform-react-display-name](https://github.com/babel/babel/blob/master/packages/babel-preset-react/index.js#L7) but this wasn't reflected in the doc page.