### PR TITLE
Add link to edit docs page in github

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -8,9 +8,15 @@ layout: default
       <div class="col-md-12">
         <h1>{{page.title}}</h1>
         <p>{{page.description}}</p>
-        {% if page.package %}
-        <p class="package-links"><a href="https://github.com/babel/babel/tree/master/packages/{{page.package}}">GitHub</a>&nbsp; · &nbsp;<a href="https://www.npmjs.com/package/{{page.package}}">npm</a></p>
-        {% endif %}
+        <p class="package-links">
+          {% if page.package %}
+          <a href="https://github.com/babel/babel/tree/master/packages/{{page.package}}">GitHub</a>
+          &nbsp; · &nbsp;
+          <a href="https://www.npmjs.com/package/{{page.package}}">npm</a>
+          &nbsp; · &nbsp;
+          {% endif %}
+          <a href="https://github.com/babel/babel.github.io/edit/master/{{page.path}}">edit this page</a>
+        </p>
       </div>
     </div>
   </div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -15,7 +15,7 @@ layout: default
           <a href="https://www.npmjs.com/package/{{page.package}}">npm</a>
           &nbsp; · &nbsp;
           {% endif %}
-          <a href="https://github.com/babel/babel.github.io/edit/master/{{page.path}}">edit this page</a>
+          <a href="https://github.com/babel/babel.github.io/edit/master/{{page.path}}">Edit this page</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
Saw a lot of other docs sites have this - I think it's good so it's easy for others to fix typos, etc.

We can change the wording too (or move it somewhere else if you don't like that).

<img width="433" alt="screen shot 2016-02-06 at 10 34 00 am" src="https://cloud.githubusercontent.com/assets/588473/12867493/2a8588a6-ccbd-11e5-8548-5a75ebc441bf.png">

<img width="525" alt="screen shot 2016-02-06 at 10 33 03 am" src="https://cloud.githubusercontent.com/assets/588473/12867487/2007b548-ccbd-11e5-8182-69c4a7b61852.png">

@thejameskyle 