### PR TITLE
Make code block render in babel-register usage docs

### DIFF
--- a/_includes/tools/babel_register/usage.md
+++ b/_includes/tools/babel_register/usage.md
@@ -7,6 +7,7 @@ require("babel-register");
 
 If you are using ES6's `import` syntax in your application's **entry point**, you
 should instead import at the top of the **entry point** to ensure it is loaded first:
+
 ```javascript
 import "babel-register";
 ```


### PR DESCRIPTION
# Changes

- Added newline above es6 example

# Why

Newline needed so it renders as code block and not as inline code.

It seems that [Github's markdown rendering](https://github.com/babel/babel.github.io/blob/master/_includes/tools/babel_register/usage.md) works without this newline but jekyll doesn't in the [live site](http://babeljs.io/docs/setup/#babel_register).