### PR TITLE
Correct the helpers path in Jasmine

### DIFF
--- a/_includes/tools/jasmine/usage.md
+++ b/_includes/tools/jasmine/usage.md
@@ -3,7 +3,7 @@ In your `spec/support/jasmine.json` file make the following changes:
 ```json
 {
   "helpers": [
-    "../../node_modules/babel-register/lib/node.js"
+    "../node_modules/babel-register/lib/node.js"
   ]
 }
 ```


### PR DESCRIPTION
According to the [example project](https://github.com/piecioshka/test-jasmine-babel/blob/master/test/jasmine.json) and [Jasmine code](https://github.com/jasmine/jasmine-npm/blob/793b7bb4f3ba4f420c7183b825ec477ebcf6eb52/lib/jasmine.js#L82), the root path of the helpers is not `spec/support` but `spec/`.

