### PR TITLE
Stack tools on setup page

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -15,16 +15,20 @@ custom_js_with_timestamps:
   <div class="step-wizard">
     <div class="step">
       <h2><span class="step-no">1</span> Choose your tool</h2>
+      
+      <div class="row">
+        {% for tool in site.data.tools %}
+          <div class="col-xs-12 col-sm-6 col-md-4">
+            <h5>{{tool.name}}</h5>
 
-      {% for tool in site.data.tools %}
-        <h5>{{tool.name}}</h5>
-
-        <div class="btn-group">
-          {% for item in tool.items %}
-            <div class="btn btn-default" data-name="{{item[0]}}">{{item[1]}}</div>
-          {% endfor %}
-        </div>
-      {% endfor %}
+            <div class="btn-group">
+              {% for item in tool.items %}
+                <div class="btn btn-default" data-name="{{item[0]}}">{{item[1]}}</div>
+              {% endfor %}
+            </div>
+          </div>
+        {% endfor %}
+      </div>
     </div>
 
     <div class="step step-install">


### PR DESCRIPTION
This change causes the tools, contained in [button groups](http://getbootstrap.com/components/#btn-groups), on the [setup page](http://babeljs.io/docs/setup/) to stack horizontally on tablet and desktop devices; saving precious vertical space.

| Small devices - Tablets (≥768px) | Medium devices - Desktops (≥992px) |
|---------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
| ![Small devices Tablets (≥768px)](https://cloud.githubusercontent.com/assets/13998/13113942/03de52ea-d5dd-11e5-85d1-47a1670c1b1f.png) | ![Medium devices Desktops (≥992px)](https://cloud.githubusercontent.com/assets/13998/13113946/088f6220-d5dd-11e5-8d34-d7c62f3c1770.png) |

The behaviour on [extra small devices](http://getbootstrap.com/css/#grid) remains the same.