### PR TITLE
Switch to NPMCDN for REPL, and load polyfill

### DIFF
--- a/repl.html
+++ b/repl.html
@@ -6,7 +6,8 @@ redirect_from: "/repl.html"
 custom_js_with_timestamps:
 - repl.js
 third_party_js:
-- https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.4.4/babel.min.js
+- https://npmcdn.com/babel-standalone@6/babel.min.js
+- https://npmcdn.com/babel-polyfill@6/dist/polyfill.min.js
 - https://cdnjs.cloudflare.com/ajax/libs/ace/1.1.3/ace.js
 ---
 <div class="babel-repl">


### PR DESCRIPTION
Fixes #748

Generator functions no longer throw an error about regeneratorRuntime not being loaded. Example URL: [http://localhost:4000/repl/#?evaluate=true&presets=es2015&experimental=false&loose=false&spec=false&code=function*%20a()%20%7B%0A%20%20yield%201%3B%0A%20%20yield%202%3B%0A%7D&playground=true](http://localhost:4000/repl/#?evaluate=true&presets=es2015&experimental=false&loose=false&spec=false&code=function*%20a()%20%7B%0A%20%20yield%201%3B%0A%20%20yield%202%3B%0A%7D&playground=true)