### PR TITLE
Add documentation for AVA test framework

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -28,7 +28,7 @@
     sails: Sails
 - name: Test frameworks
   items:
-    ava: Ava
+    ava: AVA
     jasmine: Jasmine
     jest: Jest
     karma: Karma

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -28,6 +28,7 @@
     sails: Sails
 - name: Test frameworks
   items:
+    ava: Ava
     jasmine: Jasmine
     jest: Jest
     karma: Karma

--- a/_includes/tools/ava/install.md
+++ b/_includes/tools/ava/install.md
@@ -1,0 +1,3 @@
+```sh
+$ npm install --save-dev babel-core
+```

--- a/_includes/tools/ava/install.md
+++ b/_includes/tools/ava/install.md
@@ -1,3 +1,1 @@
-```sh
-$ npm install --save-dev babel-core
-```
+There is no need to install `babel-core`, AVA bundles it already.

--- a/_includes/tools/ava/usage.md
+++ b/_includes/tools/ava/usage.md
@@ -1,8 +1,24 @@
-AVA comes with built-in support for Babel 6 and let you write your tests
-in ES2015 with no extra effort.
+AVA ships with ES2015 support built-in using Babel 6 under the hood, so
+you can write test using ES1025 syntax right away.
 
-You can customize Babel options for transpiling test files with the
-`babel` option in AVA's [`package.json` configuration](https://github.com/sindresorhus/ava#configuration).
+The AVA default Babel configuration includes the `"es2015"` and `"stage-2"`
+presets and the `"espower"` and `"transform-runtime"` plugins, corresponing to:
+
+```json
+{
+  "presets": [
+    "es2015",
+    "stage-2",
+  ],
+  "plugins": [
+    "espower",
+    "transform-runtime"
+  ]
+}
+```
+but you can customize any Babel option for transpiling test files with the
+`"babel"` option in AVA's
+[`package.json` configuration](https://github.com/sindresorhus/ava#configuration).
 
 For example:
 
@@ -20,8 +36,8 @@ For example:
 ```
 or you can simply `"inherit"` the Babel configuration from
 [`.babelrc`](/docs/usage/babelrc/) or Babel's
-[`package.json` configuration](/docs/usage/babelrc/) making test files
-use the same configuration as your source files like this:
+[`package.json` configuration](/docs/usage/babelrc/), making test files
+use the same configuration as your source files:
 
 ```json
 {

--- a/_includes/tools/ava/usage.md
+++ b/_includes/tools/ava/usage.md
@@ -1,0 +1,40 @@
+AVA comes with built-in support for Babel 6 and let you write your tests
+in ES2015 with no extra effort.
+
+You can customize Babel options for transpiling test files with the
+`babel` option in AVA's [`package.json` configuration](https://github.com/sindresorhus/ava#configuration).
+
+For example:
+
+```json
+{
+  "ava": {
+    "babel": {
+      "presets": [
+        "es2015",
+        "react"
+      ]
+    }
+  },
+}
+```
+or you can simply `"inherit"` the Babel configuration from
+[`.babelrc`](/docs/usage/babelrc/) or Babel's
+[`package.json` configuration](/docs/usage/babelrc/) making test files
+use the same configuration as your source files like this:
+
+```json
+{
+  "ava": {
+    "babel": "inherit"
+  },
+}
+```
+
+<blockquote class="babel-callout babel-callout-info">
+  <p>
+    For more information see the AVA documentation on how to
+    <a href="https://github.com/sindresorhus/ava#es2015-support">write
+    test in ES2015</a>.
+  </p>
+</blockquote>

--- a/_includes/tools/ava/usage.md
+++ b/_includes/tools/ava/usage.md
@@ -1,5 +1,5 @@
 AVA ships with ES2015 support built-in using Babel 6 under the hood, so
-you can write test using ES1025 syntax right away.
+you can write test using ES2015 syntax right away.
 
 The AVA default Babel configuration includes the `"es2015"` and `"stage-2"`
 presets and the `"espower"` and `"transform-runtime"` plugins, corresponing to:
@@ -16,7 +16,7 @@ presets and the `"espower"` and `"transform-runtime"` plugins, corresponing to:
   ]
 }
 ```
-but you can customize any Babel option for transpiling test files with the
+But you can customize any Babel option for transpiling test files with the
 `"babel"` option in AVA's
 [`package.json` configuration](https://github.com/sindresorhus/ava#configuration).
 
@@ -34,7 +34,7 @@ For example:
   },
 }
 ```
-or you can simply `"inherit"` the Babel configuration from
+Or you can simply `"inherit"` the Babel configuration from
 [`.babelrc`](/docs/usage/babelrc/) or Babel's
 [`package.json` configuration](/docs/usage/babelrc/), making test files
 use the same configuration as your source files:


### PR DESCRIPTION
Hello everyone, this is my first PR! :smile: 

While trying out AVA, I've noticed that there's no reference on the site for this test framework which heavily uses Babel for transpiling test files.

Thanks!