### PR TITLE
added jekyll-paginate to _config.yml/gems

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,7 @@ paginate: 1
 
 gems:
   - jekyll-redirect-from
+  - jekyll-paginate
 
 default_js:
   - "//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"


### PR DESCRIPTION
to mitigate ...
```
Deprecation: You appear to have pagination turned on, but you haven't included the `jekyll-paginate` gem. Ensure you have `gems: [jekyll-paginate]` in your configuration file.
```