### PR TITLE
removed make:build as bootstrap is being tracked

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "",
   "main": "",
   "scripts": {
+    "start": "make start",
     "build": "make build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
As [`bootstrap` is being tracked and checked in](https://github.com/babel/babel.github.io/tree/master/_sass/bootstrap), I guess `make:build` is not required, thus ...

* removed package.json:scripts.build
* added package.json:scripts.serve
* removed the bootstrap-sass from package.json:devDependencies
* in fact removed package.json:devDependencies

Please close the PR if it sound inappropriate. Thanks!
