### PR TITLE
add more plugins + link them to plugin pages, fix typo, misc

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@ echo '{ "presets": ["es2015"] }' > .babelrc
 // create a babel config with your presets
 echo '{ "presets": ["es2015", "react"] }' > .babelrc
 {% endhighlight %}
-      <p>Learn about <a href="https://facebook.github.io/jsx/">JSX</a> and <a href="http://flowtype.org/">Flow</a>
+      <p>Learn about <a href="https://facebook.github.io/react/docs/jsx-in-depth.html">JSX</a> and <a href="http://flowtype.org/">Flow</a>
       </p>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@ echo '{ "presets": ["es2015"] }' > .babelrc
       <p>Babel can convert JSX syntax and strip out type annotations. Check out our <a href="http://babeljs.io/docs/plugins/preset-react/">React preset</a> to get started. Use it together with the <a href="https://github.com/babel/babel-sublime">babel-sublime</a> package to bring syntax highlighting to a whole new level.</p>
 {% highlight javascript %}
 // create a babel config with your presets
-echo '{ "presets": ["es2015"] }' > .babelrc
+echo '{ "presets": ["es2015", "react"] }' > .babelrc
 {% endhighlight %}
       <p>Learn about <a href="https://facebook.github.io/jsx/">JSX</a> and <a href="http://flowtype.org/">Flow</a>
       </p>

--- a/index.html
+++ b/index.html
@@ -64,43 +64,52 @@ npm install --save-dev babel-cli babel-preset-es2015
   <div class="row featurette">
     <div class="col-md-6">
       <h2>ES2015 and beyond</h2>
-      <p>Babel has support for the latest version of JavaScript through syntax transformers. These allow you to use new syntax, <strong>right now</strong> without waiting for browser support. Check out our <a href="http://babeljs.io/docs/plugins/preset-es2015">ES2015 preset</a> to get started. <a href="/docs/learn-es2015/">Learn about ES2015 &rarr;</a></p>
+      <p>Babel has support for the latest version of JavaScript through syntax transformers. These allow you to use new syntax, <strong>right now</strong> without waiting for browser support. Check out our <a href="http://babeljs.io/docs/plugins/preset-es2015">ES2015 preset</a> to get started.</p>
+{% highlight javascript %}
+// create a babel config with your presets
+echo '{ "presets": ["es2015"] }' > .babelrc
+{% endhighlight %}
+      <p><a href="/docs/learn-es2015/">Learn about ES2015 &rarr;</a></p>
     </div>
 
     <div class="col-md-6">
       <div class="col-md-6">
         <ul class="babel-tick-list">
-          <li>Arrow functions</li>
-          <li>Async functions</li>
-          <li>Async generator functions</li>
-          <li>Classes</li>
-          <li>Class properties</li>
-          <li>Computed property names</li>
-          <li>Constants</li>
-          <li>Decorators</li>
-          <li>Default parameters</li>
-          <li>Destructuring</li>
-          <li>Exponentiation operator</li>
-          <li>For-of</li>
-          <li>Function bind</li>
+          <li><a href="/docs/plugins/transform-es2015-arrow-functions">Arrow functions</a></li>
+          <li><a href="/docs/plugins/syntax-async-functions">Async functions</a></li>
+          <li><a href="/docs/plugins/syntax-async-generators">Async generator functions</a></li>
+          <li><a href="/docs/plugins/transform-es2015-classes">Classes</a></li>
+          <li><a href="/docs/plugins/transform-class-properties">Class properties</a></li>
+          <li><a href="/docs/plugins/transform-es2015-computed-properties">Computed property names</a></li>
+          <li><a href="/docs/plugins/check-es2015-constants">Constants</a></li>
+          <li><a href="/docs/plugins/transform-decorators">Decorators</a></li>
+          <li><a href="/docs/plugins/transform-es2015-parameters">Default parameters</a></li>
+          <li><a href="/docs/plugins/transform-es2015-destructuring">Destructuring</a></li>
+          <li><a href="/docs/plugins/transform-do-expressions">Do expressions</a></li>
+          <li><a href="/docs/plugins/transform-exponentiation-operator">Exponentiation operator</a></li>
+          <li><a href="/docs/plugins/transform-es2015-for-of">For-of</a></li>
+          <li><a href="/docs/plugins/transform-function-bind">Function bind</a></li>
+          <li><a href="/docs/plugins/transform-regenerator">Generators</a></li>
         </ul>
       </div>
 
       <div class="col-md-6">
         <ul class="babel-tick-list">
-          <li>Generators</li>
-          <li>Let scoping</li>
-          <li>Modules</li>
-          <li>Module export extensions</li>
-          <li>Object rest/spread</li>
-          <li>Property method assignment</li>
-          <li>Property name shorthand</li>
-          <li>Rest parameters</li>
-          <li>React</li>
-          <li>Spread</li>
-          <li>Template literals</li>
-          <li>Type annotations</li>
-          <li>Unicode regex</li>
+          <li><a href="/docs/plugins/transform-es2015-block-scoping">Let scoping</a></li>
+          <li><a href="/docs/plugins/#modules">Modules</a></li>
+          <li><a href="/docs/plugins/transform-export-extensions">Module export extensions</a></li>
+          <li><a href="/docs/plugins/transform-es2015-literals">New literals</a></li>
+          <li><a href="/docs/plugins/transform-object-rest-spread">Object rest/spread</a></li>
+          <li><a href="/docs/plugins/transform-es2015-shorthand-properties">Property method assignment</a></li>
+          <li><a href="/docs/plugins/transform-es2015-shorthand-properties">Property name shorthand</a></li>
+          <li><a href="/docs/plugins/transform-es2015-parameters">Rest parameters</a></li>
+          <li><a href="/docs/plugins/preset-react">React</a></li>
+          <li><a href="/docs/plugins/transform-es2015-parameters">Spread</a></li>
+          <li><a href="/docs/plugins/transform-es2015-sticky-regex">Sticky regex</a></li>
+          <li><a href="/docs/plugins/transform-es2015-template-literals">Template literals</a></li>
+          <li><a href="/docs/plugins/syntax-trailing-function-commas">Trailing function commas</a></li>
+          <li><a href="/docs/plugins/transform-flow-strip-types">Type annotations</a></li>
+          <li><a href="/docs/plugins/transform-es2015-unicode-regex">Unicode regex</a></li>
         </ul>
       </div>
     </div>
@@ -129,8 +138,14 @@ npm install --save-dev babel-cli babel-preset-es2015
     </div>
 
     <div class="col-md-7">
-      <h2>JSX and React</h2>
-      <p>Babel has support for JSX and Flow. Check out our <a href="http://babeljs.io/docs/plugins/preset-react/">React preset</a> to get started. Use it together with the <a href="https://github.com/babel/babel-sublime">babel-sublime</a> package to bring syntax highlighting to a whole new level.</p>
+      <h2>JSX and Flow</h2>
+      <p>Babel can convert JSX syntax and strip out type annotations. Check out our <a href="http://babeljs.io/docs/plugins/preset-react/">React preset</a> to get started. Use it together with the <a href="https://github.com/babel/babel-sublime">babel-sublime</a> package to bring syntax highlighting to a whole new level.</p>
+{% highlight javascript %}
+// create a babel config with your presets
+echo '{ "presets": ["es2015"] }' > .babelrc
+{% endhighlight %}
+      <p>Learn about <a href="https://facebook.github.io/jsx/">JSX</a> and <a href="http://flowtype.org/">Flow</a>
+      </p>
     </div>
   </div>
 
@@ -139,7 +154,8 @@ npm install --save-dev babel-cli babel-preset-es2015
   <div class="row featurette">
     <div class="col-md-6">
       <h2>Pluggable</h2>
-      <p>Babel is built out of plugins. Compose your own transformation pipeline using existing plugins or write your own. Easily use a set of plugins by using or creating a preset. <a href="/docs/plugins/">Learn more &rarr;</a></p>
+      <p>Babel is built out of plugins. Compose your own transformation pipeline using existing plugins or write your own. Easily use a set of plugins by using or creating a <a href="/docs/plugins/#presets">preset</a>. <a href="/docs/plugins/">Learn more &rarr;</a></p>
+      <p>Create a plugin on the fly with <a href="http://astexplorer.net/#/KJ8AjD6maa">astexplorer.net</a></p>
     </div>
     <div class="col-md-6">
       <img src="{{ site.baseurl }}/images/featurettes/blueprint.png?t={{ site.time | date_to_xmlschema }}" alt="Plugins and Browsers" class="featurette-image img-responsive">


### PR DESCRIPTION
Add some more links?

<img width="1136" alt="screen shot 2016-04-02 at 10 50 12 pm" src="https://cloud.githubusercontent.com/assets/588473/14230436/49c73ce8-f925-11e5-838e-83c7cb9895bc.png">

<img width="1032" alt="screen shot 2016-04-02 at 10 59 43 pm" src="https://cloud.githubusercontent.com/assets/588473/14230468/b0e66b8c-f926-11e5-8a11-cefbcc398d6d.png">

I kind of want to switch the babel blueprint picture out with just an example plugin like on astexplorer?