### PR TITLE
Integrate Disqus on doc pages.

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -16,4 +16,24 @@ custom_js_with_timestamps:
       </div>
     </div>
   </div>
+  <div id="disqus_thread"></div>
+  <script>
+    {% if page.package %}
+    {% assign identifier = page.package %}
+    {% else %}
+    {% assign identifier = page.permalink %}
+    {% endif %}
+    var disqus_config = function () {
+      var origin = window.location.protocol + "//" + window.location.hostname +
+        (window.location.port ? ':' + window.location.port : '');
+      this.page.url = origin + "{{page.permalink}}";
+      this.page.identifier = "{{identifier}}";
+    };
+    (function() {
+      var d = document, s = d.createElement('script');
+      s.src = '//babeljs.disqus.com/embed.js';
+      s.setAttribute('data-timestamp', +new Date());
+      (d.head || d.body).appendChild(s);
+    })();
+  </script>
 </div>


### PR DESCRIPTION
After some discussion on Slack I thought it would be really nice, given that Babel doesn't have a wiki and there's ton of useful information doc readers would want, but is unfortunately scattered all over Stackoverflow, Phabricator, PRs, Medium articles & blog posts. Perhaps this would help centralize it a bit.

A useful analogue is how the comments sections on some projects (PHP, Redis, etc.) are sometimes the most useful sources of information.

Awkward if/else on 21-25 is to get around Liquid's lack of ternary operators.

I registered `babeljs.disqus.com` - happy to transfer it to whomever. I noticed `babel.disqus.com` was taken but I didn't want to take the risk that it was taken by someone unrelated to the project.
