### PR TITLE
Update AVA documentation

### DIFF
--- a/_includes/tools/ava/usage.md
+++ b/_includes/tools/ava/usage.md
@@ -2,22 +2,8 @@ AVA ships with ES2015 support built-in using Babel 6 under the hood, so
 you can write test using ES2015 syntax right away.
 
 The AVA default Babel configuration includes the `"es2015"` and `"stage-2"`
-presets and the `"espower"` and `"transform-runtime"` plugins, corresponing to:
-
-```json
-{
-  "presets": [
-    "es2015",
-    "stage-2",
-  ],
-  "plugins": [
-    "espower",
-    "transform-runtime"
-  ]
-}
-```
-But you can customize any Babel option for transpiling test files with the
-`"babel"` option in AVA's
+presets, but you can customize any Babel option for transpiling test files
+with the `"babel"` option in AVA's
 [`package.json` configuration](https://github.com/sindresorhus/ava#configuration).
 
 For example:
@@ -31,7 +17,7 @@ For example:
         "react"
       ]
     }
-  },
+  }
 }
 ```
 Or you can simply `"inherit"` the Babel configuration from
@@ -43,14 +29,19 @@ use the same configuration as your source files:
 {
   "ava": {
     "babel": "inherit"
-  },
+  }
 }
 ```
 
+Note that AVA _always_ adds a few custom Babel plugins when transpiling
+your plugins see <a
+href="https://github.com/sindresorhus/ava/blob/master/docs/recipes/babelrc.md#notes">notes</a>.
+
 <blockquote class="babel-callout babel-callout-info">
   <p>
-    For more information see the AVA documentation on how to
-    <a href="https://github.com/sindresorhus/ava#es2015-support">write
-    test in ES2015</a>.
+    For more information see the AVA recipe on <a
+    href="https://github.com/sindresorhus/ava/blob/master/docs/recipes/babelrc.md">
+    how to configure</a> Babel.
   </p>
 </blockquote>
+


### PR DESCRIPTION
Hello,

I've updated the AVA documentation, pointing the "more information" link to the AVA recipe "Configuring Babel".

@sindresorhus the AVA default Babel configuration, still includes the `"espower"` and `"transform-runtime"`plugins? Because I didn't see the being mentioned anywhere in the recipe.

Thanks!