### PR TITLE
transform-remove-console: fix typo

### DIFF
--- a/docs/plugins/transform-remove-console.md
+++ b/docs/plugins/transform-remove-console.md
@@ -36,4 +36,4 @@ Add the following line to your `.babelrc`:
 {
   "plugins": ["transform-remove-console"]
 }
-``
+```


### PR DESCRIPTION
```
`` -> ```
```