### PR TITLE
Link to a built version of the Babel 5 docs rather than the repo

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
 <div class="footer text-center">
   <p><a href="https://github.com/babel/babel">{{ site.title }}</a> · v{% include version.html %} · Distributed under MIT License</p>
-  <p><a href="https://github.com/babel/babel.github.io/tree/862b43db93e48762671267034a50c30c00e433e2">Looking for Babel 5.x docs?</a> · Found an issue with the docs? Report it <a href="https://github.com/babel/babel.github.io/issues/new">here</a>.</p>
+  <p><a href="http://henryzoo.com/babel.github.io/">Looking for Babel 5.x docs?</a> · Found an issue with the docs? Report it <a href="https://github.com/babel/babel.github.io/issues/new">here</a>.</p>
 </div>
 
 {% include scripts.html %}


### PR DESCRIPTION
- Forked @developit's version and fixed the urls https://developit.github.io/babel-legacy-docs/ (the relative links are broken)

http://henryzoo.com/babel.github.io/

<img width="1171" alt="screen shot 2016-05-29 at 7 26 05 pm" src="https://cloud.githubusercontent.com/assets/588473/15636609/3dd860ee-25d3-11e6-9d9f-7391f79043ab.png">

annoying that its changing to my cname though. or can pr their version and link to that