### PR TITLE
Add Arrow Function lexical `arguments` example

### DIFF
--- a/docs/learn-es6.md
+++ b/docs/learn-es6.md
@@ -47,7 +47,8 @@ for full specification of the ECMAScript 2015 language.
 Arrows are a function shorthand using the `=>` syntax.  They are syntactically
 similar to the related feature in C#, Java 8 and CoffeeScript.  They support
 both expression and statement bodies.  Unlike functions, arrows share the same
-lexical `this` as their surrounding code.
+lexical `this` as their surrounding code. If an arrow is inside another function, 
+it shares the "arguments" variable of its parent function.
 
 ```js
 // Expression bodies
@@ -69,6 +70,22 @@ var bob = {
       console.log(this._name + " knows " + f));
   }
 };
+
+// Lexical arguments
+function square() {
+  let example = () => {
+    let numbers = [];
+    for (number of arguments) {
+      numbers.push(number * 2);
+    }
+
+    return numbers;
+  };
+
+  return example();
+}
+
+square(2, 4, 7.5, 8, 11.5, 21); // returns: [4, 8, 15, 16, 23, 42]
 ```
 
 ### Classes


### PR DESCRIPTION
Adding a note + example about arrow functions' lexical `arguments` to spare others the [emotional distress of learning this the hard way][3].

With reference to [this][1] and [this][2]. 

Credits to @empyrical at https://github.com/lukehoban/es6features/pull/87

[1]: https://twitter.com/left_pad/status/737620004003155968
[2]: https://twitter.com/left_pad/status/737717067147825153
[3]: https://twitter.com/panda_whisperer/status/736791933142454273