### PR TITLE
External helpers doc: this → self

### DIFF
--- a/docs/plugins/external-helpers.md
+++ b/docs/plugins/external-helpers.md
@@ -45,7 +45,7 @@ You need to import/inject this file before executing your own code (instructions
 
 #### global
 
-`global` output format sets helpers as global variable by adding `babelHeleprs` to `global` or `this`.
+`global` output format sets helpers as global variable by adding `babelHelpers` to `global` or `self`.
 
 #### umd
 


### PR DESCRIPTION
In the source, the helpers are assigned to `self`, not `this`.
https://github.com/babel/babel/blob/5b89849f432cfc034860f495b5001039123e7754/packages/babel-helpers/src/helpers.js#L297