### PR TITLE
fix checkbox creation

### DIFF
--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -137,10 +137,10 @@
       $group.appendChild($label);
 
       var $input = document.createElement('input');
+      $input.type = 'checkbox';
       $input.name = 'preset';
       $input.value = presetName;
       $input.id = 'option-' + presetName;
-      $input.type = 'checkbox';
       $label.appendChild($input);
       $label.appendChild(document.createTextNode(' ' + presetName));
 


### PR DESCRIPTION
Opera had problems with this. If you create a new `<input>` element, its type defaults to  `text`. You can set a `value` now, but when you alter the type afterwards to `checkbox` the value will get replaced by the string `"on"`. Which is not a known babel preset :-/
This fix just sets the `.type`  before the `.value` to make it work again.