### PR TITLE
Clarify that callback options cannot be expressed in .babelrc files

### DIFF
--- a/docs/usage/babelrc.md
+++ b/docs/usage/babelrc.md
@@ -5,7 +5,7 @@ description: How to use the babelrc
 permalink: /docs/usage/babelrc/
 ---
 
-The entire range of Babel API [options](/docs/usage/options) are allowed.
+All Babel API [options](/docs/usage/options) except the callbacks are allowed (because `.babelrc` files are serializable JSON).
 
 **Example:**
 


### PR DESCRIPTION
Based on https://phabricator.babeljs.io/T2173, I think it's a good idea to explicitly state this in the docs