### PR TITLE
Upgrade lodash from 2.4.1 to 4.13.1 & change from // to https

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ gems:
 
 default_js:
   - "//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"
-  - "//cdnjs.cloudflare.com/ajax/libs/lodash.js/2.4.1/lodash.min.js"
+  - "//cdnjs.cloudflare.com/ajax/libs/lodash.js/4.16.3/lodash.min.js"
   - "//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.1/js/bootstrap.min.js"
 
 # Compress HTML


### PR DESCRIPTION
Paul Irish says that `//` is now an anti pattern.

Primarily, I came here to update lodash in the REPL

Thanks!