### PR TITLE
Integrate Discourse on doc pages.

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -16,4 +16,18 @@ custom_js_with_timestamps:
       </div>
     </div>
   </div>
+
+  <!-- Discourse Embed -->
+  <div id='discourse-comments'></div>
+
+  <script type="text/javascript">
+    DiscourseEmbed = { discourseUrl: 'https://discuss.babeljs.io/',
+                       discourseEmbedUrl: 'https://discuss.babeljs.io{{page.permalink}}'};
+
+    (function() {
+      var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;
+      d.src = DiscourseEmbed.discourseUrl + 'javascripts/embed.js';
+      (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
+    })();
+  </script>
 </div>


### PR DESCRIPTION
This is related to #802 - same idea but reuses the [Discourse Site](https://discuss.babeljs.io).

Unfortunately I can't test this locally - localhost needs to be an embeddable host. We'd also have to add `babeljs.io` as a host.

It would take minimal work to integrate with the existing discourse server. If nobody is willing to take the time I can do so if credentials are provided - please email if so.

[Integration Instructions](https://meta.discourse.org/t/embedding-discourse-comments-via-javascript/31963)
