### PR TITLE
Move decorators, transform-class-properties from stage-1 to stage-2 preset docs

### DIFF
--- a/docs/plugins/preset-stage-1.md
+++ b/docs/plugins/preset-stage-1.md
@@ -10,7 +10,6 @@ This preset includes the following plugins:
 
 - [transform-class-constructor-call](/docs/plugins/transform-class-constructor-call) (Deprecated)
 - [transform-class-properties](/docs/plugins/transform-class-properties)
-- <del>[transform-decorators](/docs/plugins/transform-decorators)</del> – *disabled pending proposal update*
 - [transform-export-extensions](/docs/plugins/transform-export-extensions)
 
 And all plugins from presets:

--- a/docs/plugins/preset-stage-1.md
+++ b/docs/plugins/preset-stage-1.md
@@ -9,7 +9,6 @@ package: babel-preset-stage-1
 This preset includes the following plugins:
 
 - [transform-class-constructor-call](/docs/plugins/transform-class-constructor-call) (Deprecated)
-- [transform-class-properties](/docs/plugins/transform-class-properties)
 - [transform-export-extensions](/docs/plugins/transform-export-extensions)
 
 And all plugins from presets:

--- a/docs/plugins/preset-stage-2.md
+++ b/docs/plugins/preset-stage-2.md
@@ -9,6 +9,7 @@ package: babel-preset-stage-2
 This preset includes the following plugins:
 
 - [transform-object-rest-spread](/docs/plugins/transform-object-rest-spread)
+- [transform-decorators](/docs/plugins/transform-decorators)
 
 And all plugins from presets:
 

--- a/docs/plugins/preset-stage-2.md
+++ b/docs/plugins/preset-stage-2.md
@@ -9,7 +9,7 @@ package: babel-preset-stage-2
 This preset includes the following plugins:
 
 - [transform-object-rest-spread](/docs/plugins/transform-object-rest-spread)
-- [transform-decorators](/docs/plugins/transform-decorators)
+- <del>[transform-decorators](/docs/plugins/transform-decorators)</del> – *disabled pending proposal update*
 - [transform-class-properties](/docs/plugins/transform-class-properties)
 
 And all plugins from presets:

--- a/docs/plugins/preset-stage-2.md
+++ b/docs/plugins/preset-stage-2.md
@@ -10,6 +10,7 @@ This preset includes the following plugins:
 
 - [transform-object-rest-spread](/docs/plugins/transform-object-rest-spread)
 - [transform-decorators](/docs/plugins/transform-decorators)
+- [transform-class-properties](/docs/plugins/transform-class-properties)
 
 And all plugins from presets:
 


### PR DESCRIPTION
See: https://github.com/babel/babel/pull/3613

TL; DR:
> TC39 advanced decorators to stage 2, w/ crucial open questions re:
> function, param, & property decorators needing good answers for
> progress.

- @BrendanEich