### PR TITLE
fix misinformation

### DIFF
--- a/docs/plugins/preset-es2016.md
+++ b/docs/plugins/preset-es2016.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 title: ES2016 preset
-description: All you need to compile what's in ES2016 to ES5
+description: All you need to compile what's in ES2016 to ES6 (for compiling to ES5 you need es2015 as well)
 permalink: /docs/plugins/preset-es2016/
 package: babel-preset-es2016
 ---


### PR DESCRIPTION
babel-preset-es2016 does not include es2015