### PR TITLE
Update docs to reflect preset-react update

### DIFF
--- a/docs/plugins/preset-react.md
+++ b/docs/plugins/preset-react.md
@@ -13,6 +13,7 @@ This preset includes the following plugins:
 - [transform-flow-strip-types](/docs/plugins/transform-flow-strip-types)
 - [transform-react-jsx](/docs/plugins/transform-react-jsx)
 - [transform-react-display-name](/docs/plugins/transform-react-display-name)
+- [transform-class-properties](https://babeljs.io/docs/plugins/transform-class-properties/)
 
 ## Basic Setup (with the CLI)
 


### PR DESCRIPTION
This is a change to the documentation of the react preset to reflect the change in this open [PR to the preset](https://github.com/babel/babel/pull/3654) which adds the transform-class-properties plugin. This is only a valid change if that PR is merged. 