### PR TITLE
Add latest plugin link to plugins page

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -26,8 +26,9 @@ Don't want to assemble your own set of plugins? No problem! Presets are sharable
 
 We've assembled some for common environments:
 
-> Each yearly preset only compiles what was ratified in that year. Use latest to transform all yearly presets
+> Each yearly preset only compiles what was ratified in that year. Use `preset-latest` to transform all yearly presets
 
+ - [latest](/docs/plugins/preset-latest)
  - [es2017](/docs/plugins/preset-es2017)
   - [syntax-trailing-function-commas](/docs/plugins/syntax-trailing-function-commas)
   - [transform-async-to-generator](/docs/plugins/transform-async-to-generator)


### PR DESCRIPTION
This makes the `preset-latest` plugin a bit more prominent on the page.

---

Not sure if this was intentionally left out of the list, but I think a bunch of folks would be interested in using it.