### PR TITLE
Update REPL to contain new presets

### DIFF
--- a/_sass/pages/_repl.scss
+++ b/_sass/pages/_repl.scss
@@ -86,3 +86,16 @@
 #babel-repl-presets {
   display: inline-block;
 }
+
+.babel-repl-preset-container {
+  position: relative;
+
+  .dropdown-toggle {
+    cursor: pointer;
+  }
+}
+
+#babel-repl-preset-dropdown {
+  margin-left: 10px;
+  margin-top: -3px;
+}

--- a/repl.html
+++ b/repl.html
@@ -20,8 +20,14 @@ third_party_js:
         </label>
       </div>
 
-      Presets:
-      <div id="babel-repl-presets"></div>
+      <div class="form-group button-group babel-repl-preset-container">
+        <span class="dropdown-toggle" data-toggle="dropdown">
+          Presets: <span id="babel-repl-selected-presets"></span>
+          <span class="caret"></span>
+        </span>
+        <ul class="dropdown-menu" id="babel-repl-preset-dropdown"></ul>
+      </div>
+
       <label for="option-lineWrap">
         <input id="option-lineWrap" type="checkbox">
         Line Wrap

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -1,7 +1,18 @@
 (function(babel, $, _, ace, window) {
   'use strict';
 
-  var presets = ['es2015', 'es2015-loose', 'react', 'stage-0', 'stage-1', 'stage-2', 'stage-3'];
+  var presets = [
+    'es2015',
+    'es2015-loose',
+    'es2016',
+    'es2017',
+    'latest',
+    'react',
+    'stage-0',
+    'stage-1',
+    'stage-2',
+    'stage-3'
+  ];
 
   /* Throw meaningful errors for getters of commonjs. */
   ["module", "exports", "require"].forEach(function(commonVar){
@@ -122,29 +133,54 @@
   }
 
   /**
+   * By default, Bootstrap closes dropdown menus whenever an item in them is
+   * clicked. This function overrides that behaviour for the presets dropdown,
+   * and ensures the checkbox is selected correctly.
+   */
+  function handlePresetClick($input, evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
+
+    // Needs to run in a timeout to properly handle clicks directly on the
+    // checkbox.
+    setTimeout(function() {
+      $input.checked = !$input.checked;
+      onPresetChange();
+    }, 0);
+  }
+
+  /**
    * Options for selecting presets to use.
    */
   function getPresetOptions() {
     // Create the checkboxes for all available presets
-    var $presetContainer = document.getElementById('babel-repl-presets');
+    var $presetContainer = document.getElementById('babel-repl-preset-dropdown');
     var $presets = [];
     presets.forEach(function(presetName) {
-      var $group = document.createElement('div');
-      $group.className = 'form-group';
-
-      var $label = document.createElement('label');
-      $label.htmlFor = 'option-' + presetName;
-      $group.appendChild($label);
-
       var $input = document.createElement('input');
       $input.type = 'checkbox';
       $input.name = 'preset';
       $input.value = presetName;
       $input.id = 'option-' + presetName;
+
+      // This should really be a <label>, but it *needs* to be an <a> to get the
+      // right styling. Thanks Bootstrap.
+      var $label = document.createElement('a');
+      $label.href = '#';
+      $label.className = 'small';
+      $label.tabIndex = -1;
+      $label.addEventListener(
+        'click',
+        handlePresetClick.bind(null, $input),
+        false
+      );
+
       $label.appendChild($input);
       $label.appendChild(document.createTextNode(' ' + presetName));
 
-      $presetContainer.appendChild($group);
+      var $li = document.createElement('li');
+      $li.appendChild($label);
+      $presetContainer.appendChild($li);
       $presets.push($input);
     });
 
@@ -330,6 +366,14 @@
    */
   var repl = new REPL();
 
+  function onPresetChange() {
+    // Update the list of presets that are displayed on the dropdown list anchor
+    var presetList = repl.options.presets.replace(/,/g, ', ');
+    document.getElementById('babel-repl-selected-presets').innerHTML = presetList;
+
+    onSourceChange();
+  }
+
   function onSourceChange () {
     var error;
     try {
@@ -348,5 +392,5 @@
   repl.input.on('change', _.debounce(onSourceChange, 500));
   repl.$toolBar.on('change', onSourceChange);
 
-  repl.compile();
+  onPresetChange();
 }(Babel, $, _, ace, window));


### PR DESCRIPTION
Updates the REPL to contain the new presets (es2016, es2017, latest). Since the list of presets was getting pretty long, I moved it to be a dropdown list:

![](http://ss.dan.cx/2016/08/chrome_27-12.31.03.png)

Live demo: http://babeldev.dan.cx/repl/

I had to hack around Bootstrap a bit. Its dropdowns close whenever an item within them is clicked, so I needed to add an event handler to avoid that happening. Additionally, using `<label>` tags messes up the dropdown styling, so I just used an `<a>` and handle that in the event handler. #yolo 