### PR TITLE
Fix incorrect example in `preset-es2017.md`

### DIFF
--- a/docs/plugins/preset-es2017.md
+++ b/docs/plugins/preset-es2017.md
@@ -25,7 +25,7 @@ npm install --save-dev babel-cli babel-preset-es2017
 echo '{ "presets": ["es2017"] }' > .babelrc
 
 # create a file to run on
-echo '1 ** 2' > index.js
+echo 'async function foo() { await bar(); }' > index.js
 
 # run it
 ./node_modules/.bin/babel-node index.js


### PR DESCRIPTION
`preset-es2017` does not have `transform-exponentiation-operator`.
Seems it should be fixed another example like `async/await`.