### PR TITLE
proxy console.clear() and console.error() to the real console

### DIFF
--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -356,23 +356,10 @@
       if (done) flush();
     }
 
-    capturingConsole.clear = function() {
-      buffer = [];
-      flush();
-    };
-
-    capturingConsole.error = function () {
-      error = true;
-      capturingConsole.log.apply(capturingConsole, arguments);
-    };
-
-    capturingConsole.log =
-    capturingConsole.info =
-    capturingConsole.debug = function() {
+    function capture() {
       if (this !== capturingConsole) { return; }
 
       var args = Array.prototype.slice.call(arguments);
-      Function.prototype.apply.call(console.log, console, args);
 
       var logs = args.reduce(function (logs, log) {
         if (typeof log === 'string') {
@@ -386,6 +373,24 @@
       }, []);
 
       write(logs.join(' '));
+    }
+
+    capturingConsole.clear = function() {
+      buffer = [];
+      flush();
+      console.clear();
+    };
+
+    capturingConsole.error = function() {
+      Function.prototype.apply.call(console.error, console, arguments);
+      capture.apply(this, arguments);
+    };
+
+    capturingConsole.log =
+    capturingConsole.info =
+    capturingConsole.debug = function() {
+      Function.prototype.apply.call(console.log, console, arguments);
+      capture.apply(this, arguments);
     };
 
     try {
@@ -397,8 +402,6 @@
 
     done = true;
     flush();
-
-    if (error) throw error;
   };
 
   REPL.prototype.persistState = function (state) {


### PR DESCRIPTION
I use the babel repl many times a day, and it's always been a pain that `console.clear()` and `console.error()` did not proxy to the _real_ console.

This obviously solves that.

So the common usage of adding `console.clear()` to the top of your code between REPL iterations will now clear the real console, as you would expect in JSBin, etc.