### PR TITLE
Fix lettercase for FAQ path in navbar

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -26,4 +26,4 @@
 - title: Try it out
   url: /repl/
 - title: FAQ
-  url: /docs/FAQ
+  url: /docs/faq


### PR DESCRIPTION
Clicking the FAQ link in the navbar currently results in a 404 page because `_data/navigation.yml` has the url in upper case.