### PR TITLE
proxy other console methods to their corresponding real methods

### DIFF
--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -359,8 +359,6 @@
     function capture() {
       if (this !== capturingConsole) { return; }
 
-      console.log.apply(console, arguments);
-
       var logs = _.map(arguments, function(log) {
         return window.prettyFormat(log);
       });

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -372,17 +372,12 @@
       console.clear();
     };
 
-    capturingConsole.error = function() {
-      Function.prototype.apply.call(console.error, console, arguments);
-      capture.apply(this, arguments);
-    };
-
-    capturingConsole.log =
-    capturingConsole.info =
-    capturingConsole.debug = function() {
-      Function.prototype.apply.call(console.log, console, arguments);
-      capture.apply(this, arguments);
-    };
+    ['error', 'log', 'info', 'debug'].forEach(function(key) {
+      capturingConsole[key] = function() {
+        Function.prototype.apply.call(console[key], console, arguments);
+        capture.apply(this, arguments);
+      };
+    });
 
     try {
       new Function('console', code)(capturingConsole);


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/762949/18219108/109cc1da-711c-11e6-9c63-e7a67c09450e.png)

This also removes a duplicate call to the real console that was introduced in https://github.com/babel/babel.github.io/commit/8925d2259195f1c13ddd43080252b52ba6460ef1#diff-abe23564b3ea7bb6b8680951a5f778d3R362