### PR TITLE
Change to "Set up Babel" from "Setup Babel"

### DIFF
--- a/index.html
+++ b/index.html
@@ -318,7 +318,7 @@ export default function ({types: t}) {
   <div class="text-center">
     <div class="btn-wrapper btn-wrapper-lg">
       <a href="{{ site.baseurl }}/docs/learn-es2015/" class="btn btn-featured">Learn ES2015</a>
-      <a href="{{ site.baseurl }}/docs/setup/" class="btn btn-featured">Setup Babel</a>
+      <a href="{{ site.baseurl }}/docs/setup/" class="btn btn-featured">Set up Babel</a>
       <a href="https://github.com/thejameskyle/babel-handbook" class="btn btn-featured">Babel Handbook</a>
     </div>
   </div>


### PR DESCRIPTION
In this case we want to use it as a verb. "Babel Setup" would make more sense if "setup" was kept.