### PR TITLE
Fix markdown formatting

### DIFF
--- a/docs/plugins/transform-async-generator-functions.md
+++ b/docs/plugins/transform-async-generator-functions.md
@@ -45,6 +45,7 @@ async function f() {
 ```
 
 **Example Usage**
+
 ```js
 async function* genAnswers() {
   var stream = [ Promise.resolve(4), Promise.resolve(9), Promise.resolve(12) ];


### PR DESCRIPTION
Add a newline between Example Usage and usage code.

Ref: http://babeljs.io/docs/plugins/transform-async-generator-functions/