### PR TITLE
Link to Example Node Server w/ Babel

### DIFF
--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -98,7 +98,7 @@ There are many more options available in the babel CLI, see [options](/docs/usag
     experience a startup performance penalty as the entire app needs to be compiled on the fly.
   </p>
   <p>
-    Check out the [example Node.js server with Babel](https://github.com/babel/example-node-server)
+    Check out the <a href="https://github.com/babel/example-node-server">example Node.js server with Babel</a>
     for an idea of how to use Babel in a production deployment.
   </p>
 </blockquote>

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -97,6 +97,10 @@ There are many more options available in the babel CLI, see [options](/docs/usag
     with high memory usage due to the cache being stored in memory. You will also always
     experience a startup performance penalty as the entire app needs to be compiled on the fly.
   </p>
+  <p>
+    Check out the [example Node.js server with Babel](https://github.com/babel/example-node-server)
+    for an idea of how to use Babel in a production deployment.
+  </p>
 </blockquote>
 <blockquote class="babel-callout babel-callout-info">
   <h4>ES6-style module-loading may not function as expected</h4>


### PR DESCRIPTION
[The docs](https://babeljs.io/docs/usage/cli/) currently just warn people against using `babel-node` in production.

> You should not be using `babel-node` in production.

While this may make sense to Node.js veterans, for newbies like myself it would help greatly to see an example or reference implementation of using Babel in a production deployment. Since there's already an "official" [example-node-server](https://github.com/babel/example-node-server) repo, mentioning this repo as a reference in the same warning block I believe will help more people get started with using Babel correctly.
