### PR TITLE
move setup/try buttons

### DIFF
--- a/_sass/components/_buttons.scss
+++ b/_sass/components/_buttons.scss
@@ -50,3 +50,18 @@
     }
   }
 }
+
+.jumbotron {
+  .btn-featured {
+    background: $babel-dark-gray;
+    color: $babel-yellow;
+    border-color: $babel-dark-gray;
+
+    &:hover {
+      background: $babel-yellow;
+      color: $babel-dark-gray;
+      border-color: $babel-yellow;
+    }
+  }
+
+}

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -14,7 +14,7 @@ custom_js_with_timestamps:
 <div class="container docs-content">
   <div class="step-wizard">
     <div class="step">
-      <h2><span class="step-no">1</span> Choose your tool</h2>
+      <h2><span class="step-no">1</span> Choose your tool (try CLI)</h2>
 
       {% for tool in site.data.tools %}
         <h5>{{tool.name}}</h5>

--- a/index.html
+++ b/index.html
@@ -12,6 +12,11 @@ third_party_js:
     <p>Use next generation JavaScript, today.</p>
   </div>
 
+  <div class="text-center">
+    <a href="/docs/setup" class="btn btn-featured">Setup</a>
+    <a href="http://babeljs.io/repl/#?babili=false&evaluate=true&lineWrap=false&presets=latest%2Creact%2Cstage-2&experimental=false&loose=false&spec=false&code=%5B1%2C2%2C3%5D.map(n%20%3D%3E%20n%20%2B%201)%3B&playground=true" class="btn btn-featured">Try it Out</a>
+  </div>
+
   <div class="container">
     <div class="row">
       <div class="col-md-6 col-md-offset-3">
@@ -50,12 +55,6 @@ third_party_js:
       </div>
     </div>
 
-    <div class="text-center">
-      <div class="btn-wrapper btn-wrapper-lg">
-        <a href="http://babeljs.io/repl/#?babili=false&evaluate=true&lineWrap=false&presets=latest%2Creact%2Cstage-2&experimental=false&loose=false&spec=false&code=%5B1%2C2%2C3%5D.map(n%20%3D%3E%20n%20%2B%201)%3B&playground=true" class="btn btn-featured">Try it Out</a>
-      </div>
-    </div>
-
     <h3>Start by installing the Babel CLI and a preset</h3>
     <div class="lead text-left">
 {% highlight javascript %}
@@ -70,12 +69,6 @@ $ npm install --save-dev babel-cli babel-preset-latest
   "presets": ["latest"]
 }
 {% endhighlight %}
-    </div>
-
-    <div class="text-center">
-      <div class="btn-wrapper btn-wrapper-lg">
-        <a href="/docs/setup" class="btn btn-featured">Setup</a>
-      </div>
     </div>
 
   </div>


### PR DESCRIPTION
Idea: moving the buttons to the first part of the page? (had to change the color too)

<img width="1037" alt="screen shot 2016-11-01 at 12 24 23 am" src="https://cloud.githubusercontent.com/assets/588473/19879486/9b57df40-9fc9-11e6-8298-0f1e156e0e64.png">

the Setup color is on hover/active