### PR TITLE
Fix docs sidebar

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -16,6 +16,13 @@
   {% endfor %}
 {% endif %}
 
+{% if layout.custom_js_with_timestamps %}
+  {% for js_file in layout.custom_js_with_timestamps %}
+    <script src="/scripts/{{ js_file | prepend: site.baseurl }}?t={{ site.time | date_to_xmlschema }}"
+            type="text/javascript"></script>
+  {% endfor %}
+{% endif %}
+
 {% if page.custom_js_with_timestamps %}
   {% for js_file in page.custom_js_with_timestamps %}
     <script src="/scripts/{{ js_file | prepend: site.baseurl }}?t={{ site.time | date_to_xmlschema }}"


### PR DESCRIPTION
![screen shot 2016-11-09 at 11 09 19 am](https://cloud.githubusercontent.com/assets/588473/20145157/01deb1d6-a66d-11e6-843b-cc642d9ab2c7.png)

Seems to be because docs is in _layouts so its not a `page` and the variable needs to be `layout`.. wow and I thought it was something else the whole time.

https://github.com/babel/babel.github.io/blob/83283169456d0f7c869a1eff9ab663c184692ed9/_layouts/docs.html#L3-L4

![screen shot 2016-11-09 at 11 10 55 am](https://cloud.githubusercontent.com/assets/588473/20145224/3f5fc07c-a66d-11e6-9284-a923d0e3d8c1.png)
