### PR TITLE
Clarify no-babelrc docs

### DIFF
--- a/docs/usage/options.md
+++ b/docs/usage/options.md
@@ -41,7 +41,7 @@ $ babel --name=value
 | `getModuleId`            | `null`               | Specify a custom callback to generate a module id with. Called as `getModuleId(moduleName)`. If falsy value is returned then the generated module id is used. |
 | `resolveModuleSource`    | `null`               | Resolve a module source ie. `import "SOURCE";` to a custom value. Called as `resolveModuleSource(source, filename)`. |
 | `code`                   | `true`               | Enable code generation |
-| `no-babelrc`             | CLI flag only        | Specify whether or not to use .babelrc and .babelignore files. Only available when [using the CLI](http://babeljs.io/docs/usage/cli/#ignoring-babelrc). |
+| `no-babelrc`             | [CLI flag](http://babeljs.io/docs/usage/cli/#ignoring-babelrc) | Specify whether or not to use .babelrc and .babelignore files. Only available when using the CLI. |
 | `ast`                    | `true`               | Include the AST in the returned object |
 | `compact`                | `"auto"`             | Do not include superfluous whitespace characters and line terminators. When set to `"auto"` compact is set to `true` on input sizes of >100KB. |
 | `minified`               | `false`              | Should the output be minified (not printing last semicolons in blocks, printing literal string values instead of escaped ones, stripping `()` from `new` when safe) |

--- a/docs/usage/options.md
+++ b/docs/usage/options.md
@@ -41,7 +41,7 @@ $ babel --name=value
 | `getModuleId`            | `null`               | Specify a custom callback to generate a module id with. Called as `getModuleId(moduleName)`. If falsy value is returned then the generated module id is used. |
 | `resolveModuleSource`    | `null`               | Resolve a module source ie. `import "SOURCE";` to a custom value. Called as `resolveModuleSource(source, filename)`. |
 | `code`                   | `true`               | Enable code generation |
-| `no-babelrc`             | CLI flag only        | Specify whether or not to use .babelrc and .babelignore files. Only available when using the CLI (please click [here](http://babeljs.io/docs/usage/cli/#ignoring-babelrc) for more information). |
+| `no-babelrc`             | CLI flag only        | Specify whether or not to use .babelrc and .babelignore files. Only available when [using the CLI](http://babeljs.io/docs/usage/cli/#ignoring-babelrc). |
 | `ast`                    | `true`               | Include the AST in the returned object |
 | `compact`                | `"auto"`             | Do not include superfluous whitespace characters and line terminators. When set to `"auto"` compact is set to `true` on input sizes of >100KB. |
 | `minified`               | `false`              | Should the output be minified (not printing last semicolons in blocks, printing literal string values instead of escaped ones, stripping `()` from `new` when safe) |

--- a/docs/usage/options.md
+++ b/docs/usage/options.md
@@ -41,12 +41,12 @@ $ babel --name=value
 | `getModuleId`            | `null`               | Specify a custom callback to generate a module id with. Called as `getModuleId(moduleName)`. If falsy value is returned then the generated module id is used. |
 | `resolveModuleSource`    | `null`               | Resolve a module source ie. `import "SOURCE";` to a custom value. Called as `resolveModuleSource(source, filename)`. |
 | `code`                   | `true`               | Enable code generation |
-| `babelrc`                | `true`               | Specify whether or not to use .babelrc and .babelignore files. |
+| `no-babelrc`             | CLI flag only        | Specify whether or not to use .babelrc and .babelignore files. Only available when using the CLI (please click [here](http://babeljs.io/docs/usage/cli/#ignoring-babelrc). |
 | `ast`                    | `true`               | Include the AST in the returned object |
 | `compact`                | `"auto"`             | Do not include superfluous whitespace characters and line terminators. When set to `"auto"` compact is set to `true` on input sizes of >100KB. |
 | `minified`               | `false`              | Should the output be minified (not printing last semicolons in blocks, printing literal string values instead of escaped ones, stripping `()` from `new` when safe) |
 | `comments`               | `true`               | Output comments in generated output. |
-| `shouldPrintComment`     | null                 | An optional callback that controls whether a comment should be output or not. Called as `shouldPrintComment(commentContents)`. **NOTE:** This overrides the `comment` option when used. |
+| `shouldPrintComment`     | `null`                 | An optional callback that controls whether a comment should be output or not. Called as `shouldPrintComment(commentContents)`. **NOTE:** This overrides the `comment` option when used. |
 | `env`                    | `{}`                 | This is an object of keys that represent different environments. For example, you may have: `{ env: { production: { /* specific options */ } } }` which will use those options when the enviroment variable `BABEL_ENV` is set to `"production"`. If `BABEL_ENV` isn't set then `NODE_ENV` will be used, if it's not set then it defaults to `"development"` |
 | `retainLines`            | `false`              | Retain line numbers. This will lead to wacky code but is handy for scenarios where you can't use source maps. (**NOTE:** This will not retain the columns) |
 | `extends`                | `null`               | A path to an `.babelrc` file to extend |

--- a/docs/usage/options.md
+++ b/docs/usage/options.md
@@ -41,7 +41,7 @@ $ babel --name=value
 | `getModuleId`            | `null`               | Specify a custom callback to generate a module id with. Called as `getModuleId(moduleName)`. If falsy value is returned then the generated module id is used. |
 | `resolveModuleSource`    | `null`               | Resolve a module source ie. `import "SOURCE";` to a custom value. Called as `resolveModuleSource(source, filename)`. |
 | `code`                   | `true`               | Enable code generation |
-| `no-babelrc`             | CLI flag only        | Specify whether or not to use .babelrc and .babelignore files. Only available when using the CLI (please click [here](http://babeljs.io/docs/usage/cli/#ignoring-babelrc). |
+| `no-babelrc`             | CLI flag only        | Specify whether or not to use .babelrc and .babelignore files. Only available when using the CLI (please click [here](http://babeljs.io/docs/usage/cli/#ignoring-babelrc) for more information). |
 | `ast`                    | `true`               | Include the AST in the returned object |
 | `compact`                | `"auto"`             | Do not include superfluous whitespace characters and line terminators. When set to `"auto"` compact is set to `true` on input sizes of >100KB. |
 | `minified`               | `false`              | Should the output be minified (not printing last semicolons in blocks, printing literal string values instead of escaped ones, stripping `()` from `new` when safe) |


### PR DESCRIPTION
Fixes https://github.com/babel/babel/issues/4749

This option doesn't actually have any effect when using the Node API. Goal of this PR is to clarify that this is a CLI option only.