### PR TITLE
Make REPL editors resizable by width.

### DIFF
--- a/_sass/pages/_repl.scss
+++ b/_sass/pages/_repl.scss
@@ -58,6 +58,14 @@
   background: #f9f9f9;
 }
 
+.babel-repl-resize {
+  position: absolute;
+  width: 10px;
+  height: 100%;
+  cursor: col-resize;
+  z-index: 10;
+}
+
 .babel-repl-reporter {
   position: absolute;
   z-index: 4;

--- a/_sass/pages/_repl.scss
+++ b/_sass/pages/_repl.scss
@@ -50,7 +50,6 @@
 
 .babel-repl-input {
   left: 0;
-  border-right: 1px solid darken($gray-lighter, 5%);
 }
 
 .babel-repl-output {
@@ -60,10 +59,16 @@
 
 .babel-repl-resize {
   position: absolute;
-  width: 10px;
+  width: 5px;
   height: 100%;
   cursor: col-resize;
+  background: darken($gray-lighter, 5%);
   z-index: 10;
+}
+
+.babel-repl-resize-active .babel-repl-resize,
+.babel-repl-resize:hover {
+  background: darken($gray-lighter, 10%);
 }
 
 .babel-repl-reporter {

--- a/_sass/pages/_repl.scss
+++ b/_sass/pages/_repl.scss
@@ -30,11 +30,28 @@
   }
 }
 
-.babel-repl-editor {
+.babel-repl-left-panel,
+.babel-repl-right-panel
+{
   position: absolute;
   top: 50px;
-  bottom: 30px;
+  bottom: 0;
   width: 50%;
+}
+
+.babel-repl-left-panel {
+  left: 0;
+}
+
+.babel-repl-right-panel {
+  right: 0;
+}
+
+.babel-repl-editor {
+  position: absolute;
+  top: 0;
+  bottom: 30px;
+  width: 100%;
   background: lighten($gray-lighter, 3%);
 
   .ace_editor {
@@ -48,12 +65,7 @@
   }
 }
 
-.babel-repl-input {
-  left: 0;
-}
-
 .babel-repl-output {
-  right: 0;
   background: #f9f9f9;
 }
 
@@ -78,7 +90,7 @@
   min-height: 30px;
   max-height: 30%;
   overflow: auto;
-  width: 50%;
+  width: 100%;
   padding: $padding-base-vertical $padding-base-horizontal;
   border-top: 1px solid darken($gray-lighter, 5%);
   background: lighten($gray-lighter, 1%);
@@ -89,7 +101,6 @@
 
 .babel-repl-errors {
   left: 0;
-  border-right: 1px solid darken($gray-lighter, 5%);
 }
 
 .babel-repl-console {

--- a/repl.html
+++ b/repl.html
@@ -50,7 +50,10 @@ third_party_js:
   </form>
 
   <div class="babel-repl-editor babel-repl-input"><div class="ace_editor"></div></div>
-  <div class="babel-repl-editor babel-repl-output"><div class="ace_editor"></div></div>
+  <div class="babel-repl-editor babel-repl-output">
+    <div class="babel-repl-resize"></div>
+    <div class="ace_editor"></div>
+  </div>
   <div class="babel-repl-reporter babel-repl-errors"></div>
   <div class="babel-repl-reporter babel-repl-console"></div>
 </div>

--- a/repl.html
+++ b/repl.html
@@ -49,11 +49,13 @@ third_party_js:
     </div>
   </form>
 
-  <div class="babel-repl-editor babel-repl-input"><div class="ace_editor"></div></div>
-  <div class="babel-repl-editor babel-repl-output">
-    <div class="babel-repl-resize"></div>
-    <div class="ace_editor"></div>
+  <div class="babel-repl-left-panel">
+    <div class="babel-repl-editor babel-repl-input"><div class="ace_editor"></div></div>
+    <div class="babel-repl-reporter babel-repl-errors"></div>
   </div>
-  <div class="babel-repl-reporter babel-repl-errors"></div>
-  <div class="babel-repl-reporter babel-repl-console"></div>
+  <div class="babel-repl-right-panel">
+    <div class="babel-repl-resize"></div>
+    <div class="babel-repl-editor babel-repl-output"><div class="ace_editor"></div></div>
+    <div class="babel-repl-reporter babel-repl-console"></div>
+  </div>
 </div>

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -434,8 +434,8 @@
    */
   function initResizable(resizeSelector) {
     var $container = $('.babel-repl');
-    var $leftPanels = $('.babel-repl-input, .babel-repl-errors');
-    var $rightPanels = $('.babel-repl-output, .babel-repl-console');
+    var $leftPanels = $('.babel-repl-left-panel');
+    var $rightPanels = $('.babel-repl-right-panel');
     var activeClass = 'babel-repl-resize-active';
     var offsetX;
 

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -285,6 +285,9 @@
     this.$consoleReporter = $('.babel-repl-console');
     this.$toolBar = $('.babel-repl-toolbar');
 
+    this.$inputBar = $('.babel-repl-input');
+    this.$outputBar = $('.babel-repl-output');
+
     document.getElementById('babel-repl-version').innerHTML = babel.version;
   }
 
@@ -427,5 +430,45 @@
   repl.input.on('change', _.debounce(onSourceChange, 500));
   repl.$toolBar.on('change', onSourceChange);
 
+
+  /*
+   * Make REPL editors resizable by width
+   * Returns a function to disable feature
+   */
+  function initResizable(resizeSelector) {
+    var offsetX;
+
+    function onResize(e) {
+      var containerWidth = $('.babel-repl').width();
+      var curPos = e.pageX - offsetX;
+      var inputWidth = curPos / containerWidth * 100;
+      var outputWidth = 100 - inputWidth;
+      if (inputWidth < 20 || inputWidth > 80) {
+        return;
+      }
+      repl.$inputBar.width(inputWidth + '%');
+      repl.$outputBar.width(outputWidth + '%');
+    }
+
+    function onResizeStart(e) {
+      e.preventDefault();
+      offsetX = e.offsetX;
+      $(document).on('mousemove', onResize);
+      $(document).on('mouseup', onResizeStop);
+    }
+
+    function onResizeStop(e) {
+      $(document).off('mousemove', onResize);
+      $(document).off('mouseup', onResizeStop);
+    }
+
+    $(resizeSelector).on('mousedown', onResizeStart);
+
+    return function() {
+      $(resizeSelector).off('mousedown', onResizeStart);
+    };
+  }
+
+  initResizable('.babel-repl-resize');
   onPresetChange();
 }(Babel, $, _, ace, window));

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -434,21 +434,21 @@
    */
   function initResizable(resizeSelector) {
     var $container = $('.babel-repl');
-    var $leftPanels = $('.babel-repl-left-panel');
-    var $rightPanels = $('.babel-repl-right-panel');
+    var $leftPanel = $('.babel-repl-left-panel');
+    var $rightPanel = $('.babel-repl-right-panel');
     var activeClass = 'babel-repl-resize-active';
     var offsetX;
 
     function onResize(e) {
       var curPos = e.pageX - offsetX;
-      var inputWidth = curPos / $container.width() * 100;
-      var outputWidth = 100 - inputWidth;
-      if (inputWidth < 10 || inputWidth > 90) {
+      var leftWidth = curPos / $container.width() * 100;
+      var rightWidth = 100 - leftWidth;
+      if (leftWidth < 10 || leftWidth > 90) {
         return;
       }
 
-      $leftPanels.outerWidth(inputWidth + '%');
-      $rightPanels.outerWidth(outputWidth + '%');
+      $leftPanel.outerWidth(leftWidth + '%');
+      $rightPanel.outerWidth(rightWidth + '%');
     }
 
     function onResizeStart(e) {

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -285,9 +285,6 @@
     this.$consoleReporter = $('.babel-repl-console');
     this.$toolBar = $('.babel-repl-toolbar');
 
-    this.$inputBar = $('.babel-repl-input');
-    this.$outputBar = $('.babel-repl-output');
-
     document.getElementById('babel-repl-version').innerHTML = babel.version;
   }
 
@@ -436,18 +433,22 @@
    * Returns a function to disable feature
    */
   function initResizable(resizeSelector) {
+    var $container = $('.babel-repl');
+    var $leftPanels = $('.babel-repl-input, .babel-repl-errors');
+    var $rightPanels = $('.babel-repl-output, .babel-repl-console');
+    var activeClass = 'babel-repl-resize-active';
     var offsetX;
 
     function onResize(e) {
-      var containerWidth = $('.babel-repl').width();
       var curPos = e.pageX - offsetX;
-      var inputWidth = curPos / containerWidth * 100;
+      var inputWidth = curPos / $container.width() * 100;
       var outputWidth = 100 - inputWidth;
-      if (inputWidth < 20 || inputWidth > 80) {
+      if (inputWidth < 10 || inputWidth > 90) {
         return;
       }
-      repl.$inputBar.width(inputWidth + '%');
-      repl.$outputBar.width(outputWidth + '%');
+
+      $leftPanels.outerWidth(inputWidth + '%');
+      $rightPanels.outerWidth(outputWidth + '%');
     }
 
     function onResizeStart(e) {
@@ -455,11 +456,13 @@
       offsetX = e.offsetX;
       $(document).on('mousemove', onResize);
       $(document).on('mouseup', onResizeStop);
+      $container.addClass(activeClass);
     }
 
     function onResizeStop(e) {
       $(document).off('mousemove', onResize);
       $(document).off('mouseup', onResizeStop);
+      $container.removeClass(activeClass);
     }
 
     $(resizeSelector).on('mousedown', onResizeStart);


### PR DESCRIPTION
Solves #825 

Makes resizable editor columns (10px transparent zone).
Size set in percent, panel minimum size - 20%.
![repl-resize](https://cloud.githubusercontent.com/assets/3496596/20575331/81210890-b1c1-11e6-9b4c-1a08e4bf536b.gif)
