### PR TITLE
Include docs for babili

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "_includes/babel"]
 	path = _includes/babel
 	url = https://github.com/babel/babel.git
+[submodule "_includes/babili"]
+	path = _includes/babili
+	url = https://github.com/babel/babili.git

--- a/_includes/package_readme.html
+++ b/_includes/package_readme.html
@@ -1,5 +1,12 @@
+{% if include.from %}
+  {% assign from = include.from %}
+{% else %}
+  {% assign from = "babel" %}
+{% endif %}
+
+
 {% capture readme %}
-    {% include babel/packages/{{ page.package }}/README.md %}
+    {% include {{ from }}/packages/{{ page.package }}/README.md %}
 {% endcapture %}
 
 {{ readme

--- a/docs/plugins/transform-minify-booleans.md
+++ b/docs/plugins/transform-minify-booleans.md
@@ -6,36 +6,4 @@ permalink: /docs/plugins/transform-minify-booleans/
 package: babel-plugin-transform-minify-booleans
 ---
 
-This plugin allows Babel to transform boolean literals into `!0` for `true` and `!1` for `false`.
-
-## Example
-
-**In**
-
-```javascript
-true;
-false;
-```
-
-**Out**
-
-```javascript
-!0;
-!1;
-```
-
-## Installation
-
-```sh
-$ npm install --save-dev babel-plugin-transform-minify-booleans
-```
-
-## Usage
-
-Add the following line to your `.babelrc`:
-
-```json
-{
-  "plugins": ["transform-minify-booleans"]
-}
-```
+{% include package_readme.html from="babili" %}


### PR DESCRIPTION
Refers to #999.

I wanted the API to be consistent from #990 and for #997. `from` parameter points to the source repository (`from="babel"` is by default).