### PR TITLE
Assure --outfile doesn't overwrite other files in lib directory

### DIFF
--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -56,7 +56,7 @@ $ babel script.js --out-file script-compiled.js --source-maps inline
 
 ### Compile Directories
 
-Compile the entire `src` directory and output it to the `lib` directory. You may use `--out-dir` or `-d`.
+Compile the entire `src` directory and output it to the `lib` directory. You may use `--out-dir` or `-d`. This doesn't overwrite any other files or directories in `lib`.
 
 ```sh
 $ babel src --out-dir lib


### PR DESCRIPTION
I had to check this out before compiling to `lib` because my `lib` already had other files I didn't want to overwrite.