### PR TITLE
Create Babel-types page

### DIFF
--- a/docs/core-packages/types.md
+++ b/docs/core-packages/types.md
@@ -1,17 +1,9 @@
 ---
-layout: page
+layout: docs
 title: Babel types
 description: Babel Types is a Lodash-esque utility library for AST nodes
 permalink: /docs/core-packages/types
 package: babel-types
 ---
 
-<div class="container docs-content">
-  <div class="step-wizard">
-    <div class="step">
-
-      {% include package_readme.html %}
-
-    </div>
-  </div>
-</div>
+{% include package_readme.html %}

--- a/docs/core-packages/types.md
+++ b/docs/core-packages/types.md
@@ -2,7 +2,7 @@
 layout: page
 title: Babel types
 description: Babel Types is a Lodash-esque utility library for AST nodes
-permalink: /docs/internals/types
+permalink: /docs/core-packages/types
 package: babel-types
 ---
 

--- a/docs/internals/types.md
+++ b/docs/internals/types.md
@@ -1,0 +1,17 @@
+---
+layout: page
+title: Babel types
+description: Babel Types is a Lodash-esque utility library for AST nodes
+permalink: /docs/internals/types
+package: babel-types
+---
+
+<div class="container docs-content">
+  <div class="step-wizard">
+    <div class="step">
+
+      {% include package_readme.html %}
+
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
PR related to #1006.

Babel-handbook section for `babel-types` points to the package README on Github ([see](https://github.com/thejameskyle/babel-handbook/blob/master/translations/en/plugin-handbook.md#babel-types)).

Since #990, I guess more `internal` package will be published on the website. I suggest the `/docs/internals/` path.