### PR TITLE
Fix package_readme.html include

### DIFF
--- a/_includes/package_readme.html
+++ b/_includes/package_readme.html
@@ -14,6 +14,6 @@
     | split: "<br />"
     | shift | shift | shift | shift
     | join: "<br />"
-    | strip_html
+    | remove: "<br />"
     | markdownify
 }}


### PR DESCRIPTION
As pointed out in #1010.

`strip_html` was not a good idea since some snippets (JSX for example) contains HTML.

For now, only `<br />` will be removed from snippets.