### PR TITLE
Cleanup code snippets

### DIFF
--- a/_includes/tools/babel_cli/install.md
+++ b/_includes/tools/babel_cli/install.md
@@ -11,7 +11,7 @@ There are two primary reasons for this.
 We can install Babel CLI locally by running:
 
 ```sh
-$ npm install --save-dev babel-cli
+npm install --save-dev babel-cli
 ```
 
 <blockquote class="babel-callout babel-callout-info">

--- a/_includes/tools/babel_cli/usage.md
+++ b/_includes/tools/babel_cli/usage.md
@@ -20,7 +20,7 @@ inside there as `build`.
 Now from our terminal we can run:
 
 ```sh
-$ npm run build
+npm run build
 ```
 
 This will run Babel the same way as before and the output will be present in
@@ -29,7 +29,7 @@ This will run Babel the same way as before and the output will be present in
 Alternatively, you can reference the `babel` cli inside of `node_modules`.
 
 ```sh
-$ ./node_modules/.bin/babel src -d lib
+./node_modules/.bin/babel src -d lib
 ```
 
 <blockquote class="babel-callout babel-callout-info">

--- a/_includes/tools/babel_node_debug/install.md
+++ b/_includes/tools/babel_node_debug/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install -g babel-node-debug
+npm install -g babel-node-debug
 ```

--- a/_includes/tools/babel_node_debug/usage.md
+++ b/_includes/tools/babel_node_debug/usage.md
@@ -1,9 +1,11 @@
 ```sh
-$ babel-node-debug path/to/script.js
+babel-node-debug path/to/script.js
+```
 
-# Or use the alias
+Or use the alias:
 
-$ bode-debug path/to/script.js
+```sh
+bode-debug path/to/script.js
 ```
 
 <blockquote class="babel-callout babel-callout-info">

--- a/_includes/tools/babel_register/install.md
+++ b/_includes/tools/babel_register/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install babel-register
+npm install babel-register
 ```

--- a/_includes/tools/broccoli/install.md
+++ b/_includes/tools/broccoli/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install --save-dev broccoli-babel-transpiler
+npm install --save-dev broccoli-babel-transpiler
 ```

--- a/_includes/tools/browserify/install.md
+++ b/_includes/tools/browserify/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install --save-dev babelify
+npm install --save-dev babelify
 ```

--- a/_includes/tools/browserify/usage.md
+++ b/_includes/tools/browserify/usage.md
@@ -1,7 +1,7 @@
 #### Via CLI
 
 ```sh
-$ browserify script.js -t babelify --outfile bundle.js
+browserify script.js -t babelify --outfile bundle.js
 ```
 
 #### Via Node API
@@ -30,7 +30,7 @@ browserify({ debug: true })
 **CLI**
 
 ```sh
-$ browserify -d -e script.js -t [ babelify --comments false ]
+browserify -d -e script.js -t [ babelify --comments false ]
 ```
 
 ##### Node API

--- a/_includes/tools/brunch/install.md
+++ b/_includes/tools/brunch/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install --save-dev babel-brunch
+npm install --save-dev babel-brunch
 ```

--- a/_includes/tools/connect/install.md
+++ b/_includes/tools/connect/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install babel-connect
+npm install babel-connect
 ```

--- a/_includes/tools/duo/install.md
+++ b/_includes/tools/duo/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install --save-dev duo-babel
+npm install --save-dev duo-babel
 ```

--- a/_includes/tools/duo/usage.md
+++ b/_includes/tools/duo/usage.md
@@ -1,7 +1,7 @@
 #### Via CLI
 
 ```sh
-$ duo --use duo-babel
+duo --use duo-babel
 ```
 
 #### Via Node API

--- a/_includes/tools/fly/install.md
+++ b/_includes/tools/fly/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install -D fly-babel babel-preset-latest
+npm install -D fly-babel babel-preset-latest
 ```

--- a/_includes/tools/gobble/install.md
+++ b/_includes/tools/gobble/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install --save-dev gobble-babel
+npm install --save-dev gobble-babel
 ```

--- a/_includes/tools/grunt/install.md
+++ b/_includes/tools/grunt/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install --save-dev grunt-babel
+npm install --save-dev grunt-babel
 ```

--- a/_includes/tools/gulp/install.md
+++ b/_includes/tools/gulp/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install --save-dev gulp-babel
+npm install --save-dev gulp-babel
 ```

--- a/_includes/tools/jasmine/install.md
+++ b/_includes/tools/jasmine/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install --save-dev babel-register
+npm install --save-dev babel-register
 ```

--- a/_includes/tools/jest/install.md
+++ b/_includes/tools/jest/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install --save-dev babel-jest
+npm install --save-dev babel-jest
 ```

--- a/_includes/tools/jspm/install.md
+++ b/_includes/tools/jspm/install.md
@@ -1,5 +1,5 @@
 Select `babel` as the transpiler when running `jspm init -p` or to switch an existing project into Babel use:
 
 ```sh
-  jspm dl-loader --babel
+jspm dl-loader --babel
 ```

--- a/_includes/tools/karma/install.md
+++ b/_includes/tools/karma/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install --save-dev karma-babel-preprocessor
+npm install --save-dev karma-babel-preprocessor
 ```

--- a/_includes/tools/lab/install.md
+++ b/_includes/tools/lab/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install --save-dev lab-babel
+npm install --save-dev lab-babel
 ```

--- a/_includes/tools/make/usage.md
+++ b/_includes/tools/make/usage.md
@@ -9,5 +9,5 @@ lib/%.js: src/%.js .babelrc
 ```
 
 ```sh
-$ make
+make
 ```

--- a/_includes/tools/meteor/install.md
+++ b/_includes/tools/meteor/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ meteor add ecmascript
+meteor add ecmascript
 ```

--- a/_includes/tools/mocha/install.md
+++ b/_includes/tools/mocha/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install --save-dev babel-register
+npm install --save-dev babel-register
 ```

--- a/_includes/tools/mocha/usage.md
+++ b/_includes/tools/mocha/usage.md
@@ -1,6 +1,6 @@
 In your `package.json` file make the following changes:
 
-```js
+```json
 {
   "scripts": {
     "test": "mocha --compilers js:babel-register"
@@ -10,11 +10,11 @@ In your `package.json` file make the following changes:
 
 Some features will require a polyfill:
 
-```bash
-$ npm install --save-dev babel-polyfill
+```sh
+npm install --save-dev babel-polyfill
 ```
 
-```js
+```json
 {
   "scripts": {
     "test": "mocha --require babel-polyfill --compilers js:babel-register"

--- a/_includes/tools/node/install.md
+++ b/_includes/tools/node/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install --save-dev babel-core
+npm install --save-dev babel-core
 ```

--- a/_includes/tools/nodemon/install.md
+++ b/_includes/tools/nodemon/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install babel-cli babel-preset-latest --save-dev
+npm install babel-cli babel-preset-latest --save-dev
 ```

--- a/_includes/tools/nodemon/usage.md
+++ b/_includes/tools/nodemon/usage.md
@@ -1,6 +1,6 @@
 In your `package.json` file make the following changes:
 
-```js
+```json
 {
   "scripts": {
     "babel-node": "babel-node --presets=/*a*/ --ignore='foo|bar|baz'"
@@ -11,7 +11,7 @@ In your `package.json` file make the following changes:
 Then call your script with:
 
 ```sh
-$ nodemon --exec npm run babel-node -- path/to/script.js
+nodemon --exec npm run babel-node -- path/to/script.js
 ```
 
 #### Arguments caveat
@@ -19,5 +19,5 @@ $ nodemon --exec npm run babel-node -- path/to/script.js
 Calling nodemon with babel-node may lead to arguments getting parsed incorrectly if you forget to use a double dash. Using npm-scripts helpers prevent this. If you chose to skip using npm-scripts, it can be expressed as:
 
 ```sh
-$ nodemon --exec babel-node --presets=es2015 --ignore='foo\|bar\|baz' -- path/to/script.js
+nodemon --exec babel-node --presets=es2015 --ignore='foo\|bar\|baz' -- path/to/script.js
 ```

--- a/_includes/tools/pug/install.md
+++ b/_includes/tools/pug/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install jstransformer-babel
+npm install jstransformer-babel
 ```

--- a/_includes/tools/rails/install.md
+++ b/_includes/tools/rails/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ gem install sprockets-es6
+gem install sprockets-es6
 ```

--- a/_includes/tools/requirejs/install.md
+++ b/_includes/tools/requirejs/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install requirejs-babel
+npm install requirejs-babel
 ```

--- a/_includes/tools/rollup/install.md
+++ b/_includes/tools/rollup/install.md
@@ -1,6 +1,13 @@
 ```sh
-$ npm install --save-dev rollup
-$ npm install --save-dev rollup-plugin-babel
-# Instead of the es2015 preset
-$ npm install --save-dev babel-preset-es2015-rollup
+npm install --save-dev rollup
+```
+
+```sh
+npm install --save-dev rollup-plugin-babel
+```
+
+Instead of the `es2015` preset:
+
+```sh
+npm install --save-dev babel-preset-es2015-rollup
 ```

--- a/_includes/tools/ruby/install.md
+++ b/_includes/tools/ruby/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ gem install babel-transpiler
+gem install babel-transpiler
 ```

--- a/_includes/tools/sails/install.md
+++ b/_includes/tools/sails/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install --save-dev sails-hook-babel
+npm install --save-dev sails-hook-babel
 ```

--- a/_includes/tools/sprockets/install.md
+++ b/_includes/tools/sprockets/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ gem install sprockets-es6
+gem install sprockets-es6
 ```

--- a/_includes/tools/start/install.md
+++ b/_includes/tools/start/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install -D start-babel
+npm install -D start-babel
 ```

--- a/_includes/tools/webpack/install.md
+++ b/_includes/tools/webpack/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install --save-dev babel-loader babel-core
+npm install --save-dev babel-loader babel-core
 ```

--- a/_includes/tools/webstorm/install.md
+++ b/_includes/tools/webstorm/install.md
@@ -1,3 +1,3 @@
 ```sh
-$ npm install --save-dev babel-cli
+npm install --save-dev babel-cli
 ```

--- a/_sass/components/_type.scss
+++ b/_sass/components/_type.scss
@@ -6,7 +6,10 @@ pre.highlight {
   color: $babel-dark-gray;
   padding: 1em;
 }
-code.language-shell:before {
+code.language-shell:before,
+.language-shell code:before,
+.language-sh code:before {
+  color: grey;
   content: "$ ";
 }
 

--- a/_sass/components/_type.scss
+++ b/_sass/components/_type.scss
@@ -6,6 +6,9 @@ pre.highlight {
   color: $babel-dark-gray;
   padding: 1em;
 }
+code.language-shell:before {
+  content: "$ ";
+}
 
 table {
   @extend .table;

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -50,7 +50,7 @@ custom_js_with_timestamps:
       </p>
 
 <!--lint disable no-shortcut-reference-link, no-undefined-references-->
-{% highlight js %}
+{% highlight shell %}
 npm install babel-preset-latest --save-dev
 {% endhighlight %}
 <!--lint enable no-shortcut-reference-link, no-undefined-references-->
@@ -68,8 +68,15 @@ npm install babel-preset-latest --save-dev
 <!--lint enable no-shortcut-reference-link, no-undefined-references-->
 
       <p>
-        <strong>Note</strong>: Running a Babel 6.x project using npm 2.x can cause performance problems because of the way npm 2.x installs dependencies. This problem can be eliminated by either switching to npm 3.x or running npm 2.x with the <a href="https://docs.npmjs.com/cli/dedupe">dedupe</a> flag. To check what version of npm you have run <div class="highlight"><pre>npm --version</pre></div>
+        <strong>Note</strong>: Running a Babel 6.x project using npm 2.x can cause performance problems because of the way npm 2.x installs dependencies. This problem can be eliminated by either switching to npm 3.x or running npm 2.x with the <a href="https://docs.npmjs.com/cli/dedupe">dedupe</a> flag. To check what version of npm you have run
       </p>
+
+<!--lint disable no-shortcut-reference-link, no-undefined-references-->
+{% highlight shell %}
+npm --version
+{% endhighlight %}
+<!--lint enable no-shortcut-reference-link, no-undefined-references-->
+
     </div>
   </div>
 </div>

--- a/docs/usage/babel-register.md
+++ b/docs/usage/babel-register.md
@@ -16,7 +16,7 @@ fly. This is equivalent to CoffeeScript's
 ## Install
 
 ```sh
-$ npm install babel-register --save-dev
+npm install babel-register --save-dev
 ```
 
 ## Usage
@@ -91,7 +91,7 @@ environment variables exposed to allow you to do this.
 Specify a different cache location.
 
 ```sh
-$ BABEL_CACHE_PATH=/foo/my-cache.json babel-node script.js
+BABEL_CACHE_PATH=/foo/my-cache.json babel-node script.js
 ```
 
 ### BABEL_DISABLE_CACHE
@@ -99,5 +99,5 @@ $ BABEL_CACHE_PATH=/foo/my-cache.json babel-node script.js
 Disable the cache.
 
 ```sh
-$ BABEL_DISABLE_CACHE=1 babel-node script.js
+BABEL_DISABLE_CACHE=1 babel-node script.js
 ```

--- a/docs/usage/babelrc.md
+++ b/docs/usage/babelrc.md
@@ -23,7 +23,7 @@ All Babel API [options](/docs/usage/options) except the callbacks are allowed (b
 
 You can alternatively choose to specify your `.babelrc` config from within `package.json` like so:
 
-```javascript
+```json
 {
   "name": "my-package",
   "version": "1.0.0",
@@ -56,20 +56,28 @@ You can set this environment variable with the following:
 
 **Unix**
 
-```sh
-# at the start of a command
-$ BABEL_ENV=production YOUR_COMMAND_HERE
+At the start of a command:
 
-# or as a separate command
-$ NODE_ENV=production
-$ YOUR_COMMAND_HERE
+```sh
+BABEL_ENV=production YOUR_COMMAND_HERE
+```
+
+Or as a separate command:
+
+```sh
+NODE_ENV=production
+```
+```sh
+YOUR_COMMAND_HERE
 ```
 
 **Windows**
 
 ```sh
-$ SET BABEL_ENV=production
-$ YOUR_COMMAND_HERE
+SET BABEL_ENV=production
+```
+```sh
+YOUR_COMMAND_HERE
 ```
 
 ## Lookup behavior

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -23,20 +23,20 @@ package: babel-cli
 Compile the file `script.js` and **output to stdout**.
 
 ```sh
-$ babel script.js
+babel script.js
 # output...
 ```
 
 If you would like to **output to a file** you may use `--out-file` or `-o`.
 
 ```sh
-$ babel script.js --out-file script-compiled.js
+babel script.js --out-file script-compiled.js
 ```
 
 To compile a file **every time that you change it**, use the `--watch` or `-w` option:
 
 ```sh
-$ babel script.js --watch --out-file script-compiled.js
+babel script.js --watch --out-file script-compiled.js
 ```
 
 ### Compile with Source Maps
@@ -45,13 +45,13 @@ If you would then like to add a **source map file** you can use
 `--source-maps` or `-s`. [Learn more about source maps](http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/).
 
 ```sh
-$ babel script.js --out-file script-compiled.js --source-maps
+babel script.js --out-file script-compiled.js --source-maps
 ```
 
 If you would rather have **inline source maps**, you may use `--source-maps inline`.
 
 ```sh
-$ babel script.js --out-file script-compiled.js --source-maps inline
+babel script.js --out-file script-compiled.js --source-maps inline
 ```
 
 ### Compile Directories
@@ -59,13 +59,13 @@ $ babel script.js --out-file script-compiled.js --source-maps inline
 Compile the entire `src` directory and output it to the `lib` directory. You may use `--out-dir` or `-d`. This doesn't overwrite any other files or directories in `lib`.
 
 ```sh
-$ babel src --out-dir lib
+babel src --out-dir lib
 ```
 
 Compile the entire `src` directory and output it to the one concatenated file.
 
 ```sh
-$ babel src --out-file script-compiled.js
+babel src --out-file script-compiled.js
 ```
 
 ### Ignore files
@@ -73,7 +73,7 @@ $ babel src --out-file script-compiled.js
 Ignore spec and test files
 
 ```sh
-$ babel src --out-dir lib --ignore spec.js,test.js
+babel src --out-dir lib --ignore spec.js,test.js
 ```
 
 ### Copy files
@@ -81,7 +81,7 @@ $ babel src --out-dir lib --ignore spec.js,test.js
 Copy files that will not be compiled
 
 ```sh
-$ babel src --out-dir lib --copy-files
+babel src --out-dir lib --copy-files
 ```
 
 ### Piping Files
@@ -89,7 +89,7 @@ $ babel src --out-dir lib --copy-files
 Pipe a file in via stdin and output it to `script-compiled.js`
 
 ```sh
-$ babel --out-file script-compiled.js < script.js
+babel --out-file script-compiled.js < script.js
 ```
 
 ### Using Plugins
@@ -97,7 +97,7 @@ $ babel --out-file script-compiled.js < script.js
 Use the `--plugins` option to specify plugins to use in compilation
 
 ```sh
-$ babel script.js --out-file script-compiled.js --plugins=es2015,react
+babel script.js --out-file script-compiled.js --plugins=es2015,react
 ```
 
 ### Using Presets
@@ -105,7 +105,7 @@ $ babel script.js --out-file script-compiled.js --plugins=es2015,react
 Use the `--presets` option to specify plugins to use in compilation
 
 ```sh
-$ babel script.js --out-file script-compiled.js --presets=add-module-exports,transform-es2015-modules-amd
+babel script.js --out-file script-compiled.js --presets=add-module-exports,transform-es2015-modules-amd
 ```
 
 ### Ignoring .babelrc
@@ -113,7 +113,7 @@ $ babel script.js --out-file script-compiled.js --presets=add-module-exports,tra
 Ignore the configuration from the projects .babelrc file and use the cli options e.g. for a custom build
 
 ```sh
-$ babel --no-babelrc script.js --out-file script-compiled.js --presets=add-module-exports,transform-es2015-modules-amd
+babel --no-babelrc script.js --out-file script-compiled.js --presets=add-module-exports,transform-es2015-modules-amd
 ```
 
 ### Advanced Usage
@@ -148,31 +148,31 @@ it will compile ES6 code before running it.
 Launch a REPL (Read-Eval-Print-Loop).
 
 ```sh
-$ babel-node
+babel-node
 ```
 
 Evaluate code.
 
 ```sh
-$ babel-node -e "class Test { }"
+babel-node -e "class Test { }"
 ```
 
 Compile and run `test.js`.
 
 ```sh
-$ babel-node test
+babel-node test
 ```
 
 ### Usage
 
 ```sh
-$ babel-node [options] [ -e script | script.js ] [arguments]
+babel-node [options] [ -e script | script.js ] [arguments]
 ```
 
 When arguments for user script have names conflicting with node options, double dash placed before script name can be used to resolve ambiguities
 
 ```sh
-$ babel-node --debug --presets es2015 -- script.js --debug
+babel-node --debug --presets es2015 -- script.js --debug
 ```
 
 ### Options

--- a/docs/usage/options.md
+++ b/docs/usage/options.md
@@ -12,7 +12,7 @@ babel.transform(code, options);
 ```
 
 ```sh
-$ babel --name=value
+babel --name=value
 ```
 
 ## Options

--- a/docs/usage/polyfill.md
+++ b/docs/usage/polyfill.md
@@ -28,7 +28,7 @@ Note: Depending on what ES2015 methods you actually use, you may not need to use
 ## Installation
 
 ```sh
-$ npm install --save-dev babel-polyfill
+npm install --save-dev babel-polyfill
 ```
 
 ## Usage in Node / Browserify / Webpack

--- a/index.html
+++ b/index.html
@@ -57,8 +57,8 @@ third_party_js:
 
     <h3>Start by installing the Babel CLI and a preset</h3>
     <div class="lead text-left">
-{% highlight javascript %}
-$ npm install --save-dev babel-cli babel-preset-latest
+{% highlight shell %}
+npm install --save-dev babel-cli babel-preset-latest
 {% endhighlight %}
     </div>
 
@@ -81,8 +81,8 @@ $ npm install --save-dev babel-cli babel-preset-latest
       <p>Babel has support for the latest version of JavaScript through syntax transformers. These plugins allow you to use new syntax, <strong>right now</strong> without waiting for browser support. Check out our <a href="https://babeljs.io/docs/plugins/preset-latest">Latest preset</a> to get started.</p>
 
       <p>You can install this preset with</p>
-{% highlight javascript %}
-$ npm install --save-dev babel-preset-latest
+{% highlight shell %}
+npm install --save-dev babel-preset-latest
 {% endhighlight %}
       </p>and add <code>"latest"</code> to your <code>.babelrc</code> presets array.</p>
     </div>
@@ -141,8 +141,8 @@ $ npm install --save-dev babel-preset-latest
         <p>Since Babel only transforms syntax (like arrow functions), you can use babel-polyfill in order to support new globals such as Promise or new native methods like String.padStart (left-pad). It uses <a href="https://github.com/zloirock/core-js">core-js</a> and <a href="https://facebook.github.io/regenerator/">regenerator</a>. Check out our <a href="/docs/usage/polyfill">babel-polyfill</a> docs for more info.</p>
 
         <p>You can install the polyfill with</p>
-{% highlight javascript %}
-$ npm install --save-dev babel-polyfill
+{% highlight shell %}
+npm install --save-dev babel-polyfill
 {% endhighlight %}
         <p>Use it by requiring it at the top of the entry point to your application or in your bundler config.</p>
       </div>
@@ -209,8 +209,8 @@ $ npm install --save-dev babel-polyfill
       <p>Babel can convert JSX syntax and strip out type annotations. Check out our <a href="https://babeljs.io/docs/plugins/preset-react/">React preset</a> to get started. Use it together with the <a href="https://github.com/babel/babel-sublime">babel-sublime</a> package to bring syntax highlighting to a whole new level.</p>
 
       <p>You can install this preset with</p>
-{% highlight javascript %}
-$ npm install --save-dev babel-preset-react
+{% highlight shell %}
+npm install --save-dev babel-preset-react
 {% endhighlight %}
       </p>and add <code>"react"</code> to your <code>.babelrc</code> presets array.</p>
       </p>


### PR DESCRIPTION
For issue: `Cleanup code snippets after` #1002 
Previous PR: #1013 (sorry about this)

- Split & fix `tools/` and `docs/usage` code snippets
- Main page: Changed cli commands highlights `javascript` to `shell`
- Add "$ " to :before content

In next commit will fix `plugins/`