### PR TITLE
Provide a keyboard shortcut to get to the search box.

### DIFF
--- a/scripts/search.js
+++ b/scripts/search.js
@@ -42,8 +42,14 @@
                     return;
             }
 
-            event.preventDefault();
-            $toggleCheckbox.click();
+            // don't type '/' or '?', if the search box is closed or it's not
+            // focused (i.e. to regain focus, without typing the character)
+            if (!$toggleCheckbox.prop('checked') ||
+                !$searchInput.is(':focus')) {
+                    event.preventDefault();
+            }
+
+            $toggleCheckbox.prop('checked', true);
             $searchInput.focus();
         });
 

--- a/scripts/search.js
+++ b/scripts/search.js
@@ -8,6 +8,7 @@
     var KEYBOARD_ESCAPE = 27;
     var KEYBOARD_SLASH = 47;
     var KEYBOARD_QUESTION_MARK = 63;
+    var KEYBOARD_S = 115;
 
     // config is https://github.com/algolia/docsearch-configs/blob/master/configs/babeljs.json
     var $search = docsearch({
@@ -33,12 +34,13 @@
             $searchInput.focus();
         });
 
-        // Open the search when pressing / or ?
+        // Open the search when pressing / or ? or s
         // Use 'keypress' events to handle key combos
         // (e.g. en: '?' = Shift + '/')
         $(document).on('keypress', function(event) {
             if (event.keyCode !== KEYBOARD_SLASH &&
-                event.keyCode !== KEYBOARD_QUESTION_MARK) {
+                event.keyCode !== KEYBOARD_QUESTION_MARK &&
+                event.keyCode !== KEYBOARD_S) {
                     return;
             }
 

--- a/scripts/search.js
+++ b/scripts/search.js
@@ -5,6 +5,10 @@
     var $selector = '#babel-search-input';
     var $searchInput = $($selector);
 
+    var KEYBOARD_ESCAPE = 27;
+    var KEYBOARD_SLASH = 47;
+    var KEYBOARD_QUESTION_MARK = 63;
+
     // config is https://github.com/algolia/docsearch-configs/blob/master/configs/babeljs.json
     var $search = docsearch({
         apiKey: 'd42906b043c5422ea07b44fd49c40a0d',
@@ -31,9 +35,11 @@
 
         // Open the search when pressing / or ?
         // Use 'keypress' events to handle key combos
+        // (e.g. en: '?' = Shift + '/')
         $(document).on('keypress', function(event) {
-            if (event.keyCode !== 47 && event.keyCode !== 63) {
-                return;
+            if (event.keyCode !== KEYBOARD_SLASH &&
+                event.keyCode !== KEYBOARD_QUESTION_MARK) {
+                    return;
             }
 
             event.preventDefault();
@@ -43,7 +49,7 @@
 
         // Hide the search when pressing Escape
         $(document).on('keydown', function(event) {
-            if (event.keyCode !== 27) {
+            if (event.keyCode !== KEYBOARD_ESCAPE) {
                 return;
             }
             $toggleCheckbox.prop('checked', false);

--- a/scripts/search.js
+++ b/scripts/search.js
@@ -38,9 +38,12 @@
         // Use 'keypress' events to handle key combos
         // (e.g. en: '?' = Shift + '/')
         $(document).keypress(function(event) {
-            if (event.which !== KEYBOARD_SLASH &&
-                event.which !== KEYBOARD_QUESTION_MARK &&
-                event.which !== KEYBOARD_S) {
+            // omit functionality if another input-element is currently in
+            // focus or the input key is not in the list of accepted keys
+            if ($(document.activeElement).is(':input') ||
+                (event.which !== KEYBOARD_SLASH &&
+                 event.which !== KEYBOARD_QUESTION_MARK &&
+                 event.which !== KEYBOARD_S)) {
                     return;
             }
 
@@ -64,6 +67,11 @@
             // clear search input and close the search box
             $searchInput.val('');
             $toggleCheckbox.prop('checked', false);
+
+            // blur focus on the active element
+            // NOTE: this will also blur the focus of any other currently
+            //       active element
+            $(document.activeElement).blur();
         });
     });
 })(jQuery);

--- a/scripts/search.js
+++ b/scripts/search.js
@@ -52,8 +52,10 @@
             if (event.keyCode !== KEYBOARD_ESCAPE) {
                 return;
             }
+
+            // clear search input and close the search box
+            $searchInput.val('');
             $toggleCheckbox.prop('checked', false);
         });
-
     });
 })(jQuery);

--- a/scripts/search.js
+++ b/scripts/search.js
@@ -29,6 +29,18 @@
             $searchInput.focus();
         });
 
+        // Open the search when pressing / or ?
+        // Use 'keypress' events to handle key combos
+        $(document).on('keypress', function(event) {
+            if (event.keyCode !== 47 && event.keyCode !== 63) {
+                return;
+            }
+
+            event.preventDefault();
+            $toggleCheckbox.click();
+            $searchInput.focus();
+        });
+
         // Hide the search when pressing Escape
         $(document).on('keydown', function(event) {
             if (event.keyCode !== 27) {

--- a/scripts/search.js
+++ b/scripts/search.js
@@ -37,10 +37,10 @@
         // Open the search when pressing / or ? or s
         // Use 'keypress' events to handle key combos
         // (e.g. en: '?' = Shift + '/')
-        $(document).on('keypress', function(event) {
-            if (event.keyCode !== KEYBOARD_SLASH &&
-                event.keyCode !== KEYBOARD_QUESTION_MARK &&
-                event.keyCode !== KEYBOARD_S) {
+        $(document).keypress(function(event) {
+            if (event.which !== KEYBOARD_SLASH &&
+                event.which !== KEYBOARD_QUESTION_MARK &&
+                event.which !== KEYBOARD_S) {
                     return;
             }
 
@@ -56,8 +56,8 @@
         });
 
         // Hide the search when pressing Escape
-        $(document).on('keydown', function(event) {
-            if (event.keyCode !== KEYBOARD_ESCAPE) {
+        $(document).keydown(function(event) {
+            if (event.which !== KEYBOARD_ESCAPE) {
                 return;
             }
 


### PR DESCRIPTION
This PR should implement a solution for issue #1027 

It adds an event-handler for the 'keypress' event, that checks the key codes
and opens the searchInput box. It is necessary to use the 'keypress'
event, as the question mark is a key combo on the us-en keyboard layout
(and de-de and possibly others, too).

EDIT @aaronang: Fixes #1027.