### PR TITLE
Fix bug with duplicate heading hashes

### DIFF
--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -20,8 +20,10 @@
   var current;
 
   $('h2, h3').each(function(index, heading) {
+    var isSubHeading = heading.tagName.toUpperCase() !== 'H2';
     var textContent = heading.textContent;
-    var id = dasherize(textContent);
+    var idPrefix = isSubHeading && current ? current.id : '';
+    var id = dasherize(idPrefix + textContent);
 
     heading.id = id;
 
@@ -32,7 +34,7 @@
       children: []
     };
 
-    if (heading.tagName.toUpperCase() === 'H2') {
+    if (!isSubHeading) {
       headings.push(value);
       current = value;
     } else {


### PR DESCRIPTION
Currently, because we have two headings with the text "Experimental" we get:
![image](https://cloud.githubusercontent.com/assets/56288/20897398/c62f51d8-bae7-11e6-9a99-2293684274bc.png)

This concats the parent's hash to fix this issue:
![image](https://cloud.githubusercontent.com/assets/56288/20897477/29d4b8f4-bae8-11e6-8e66-5c1d01e15eca.png)

And, the headings linkable:
./docs/plugins/#transform-plugins-experimental
./docs/plugins/#syntax-plugins-experimental