### PR TITLE
Grouping elements in navbar

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -3,24 +3,31 @@
 - title: Docs
   url: /docs
   subnav:
-  - title: Setup
-    url: /docs/setup/
-  - title: Plugins
-    url: /docs/plugins/
-  - title: Polyfill
-    url: /docs/usage/polyfill/
-  - title: Caveats
-    url: /docs/usage/caveats/
-  - title: Editors
-    url: /docs/editors
-  - title: API
-    url: /docs/usage/api/
-  - title: CLI
-    url: /docs/usage/cli/
-  - title: babel-register
-    url: /docs/usage/babel-register/
-  - title: .babelrc
-    url: /docs/usage/babelrc/
+    - items:
+        - title: Setup
+          url: /docs/setup/
+        - title: Editors
+          url: /docs/editors
+        - title: Caveats
+          url: /docs/usage/caveats/
+    - name: Packages
+      items:
+        - title: API
+          url: /docs/core-packages/
+        - title: Plugins
+          url: /docs/plugins/
+        - title: Polyfill
+          url: /docs/usage/polyfill/
+    - name: Usage
+      items:
+        - title: CLI
+          url: /docs/usage/cli/
+        - title: babel-register
+          url: /docs/usage/babel-register/
+        - title: .babelrc
+          url: /docs/usage/babelrc/
+        - title: Browser
+          url: /docs/usage/browser/
 - title: Try it out
   url: /repl/
 - title: Blog

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -12,7 +12,7 @@
           url: /docs/usage/caveats/
     - name: Packages
       items:
-        - title: API
+        - title: Core
           url: /docs/core-packages/
         - title: Plugins
           url: /docs/plugins/

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -23,10 +23,19 @@
             <li class="dropdown {% if page.url contains item.url %}active{% endif %}">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">{{ item.title }} <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                {% for item in item.subnav %}
-                  <li {% if page.url contains item.url %}class="active"{% endif %}>
-                    <a href="{{ item.url | prepend: site.baseurl }}">{{ item.title }}</a>
-                  </li>
+                {% for group in item.subnav %}
+
+                  {% if group.name %}
+                    <li class="group-name">{{ group.name }}</li>
+                  {% endif %}
+
+                  {% for item in group.items %}
+
+                    <li {% if page.url contains item.url %}class="active"{% endif %}>
+                      <a href="{{ item.url | prepend: site.baseurl }}">{{ item.title }}</a>
+                    </li>
+                  {% endfor %}
+
                 {% endfor %}
               </ul>
             </li>

--- a/_sass/components/_navbar.scss
+++ b/_sass/components/_navbar.scss
@@ -16,5 +16,14 @@
 }
 
 .group-name {
-  margin: 6px;
+  border-bottom: 1px solid #E0E0E0;
+  padding: 0 0 8px;
+  margin: 17px 20px 8px;
+
+  @media (max-width: $grid-float-breakpoint-max) {
+    border-bottom-color: #BFAA42;
+    margin-left: 25px;
+    margin-right: 15px;
+  }
 }
+

--- a/_sass/components/_navbar.scss
+++ b/_sass/components/_navbar.scss
@@ -14,3 +14,7 @@
     padding-right: 10px;
   }
 }
+
+.group-name {
+  margin: 6px;
+}


### PR DESCRIPTION
Fixes #1060

#### Desktop:
![nav-desktop](https://cloud.githubusercontent.com/assets/1493671/21074242/8d1c2afe-bef4-11e6-83ac-84a9db988ba4.png)

 #### Collasped:
![nav-mobile](https://cloud.githubusercontent.com/assets/1493671/21074243/8d1d037a-bef4-11e6-8aea-d211dfed1e3b.png)

Given #1042 this is a quick fix.

Navigation data has a bit changed:
* actual item
* subnav
    * name (optionnaly set a group name)
    * items
        * actual item