### PR TITLE
add support for GitHub emojis

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,7 @@ paginate: 1
 gems:
   - jekyll-redirect-from
   - jekyll-paginate
+  - jemoji
 
 default_js:
   - "//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"


### PR DESCRIPTION
Ref #1046 

It appears that [jemoji](https://github.com/jekyll/jemoji) is one of the [very few plugins](https://pages.github.com/versions/) supported by github pages 💥

Tested it by adding the changelog page:

<img width="927" alt="screen shot 2016-12-11 at 9 41 10 am" src="https://cloud.githubusercontent.com/assets/927264/21082007/24fd6bc0-bf87-11e6-9712-de884969d590.png">
 