### PR TITLE
reference preset-env instead of latest

### DIFF
--- a/_posts/2015-10-31-setting-up-babel-6.md
+++ b/_posts/2015-10-31-setting-up-babel-6.md
@@ -82,12 +82,12 @@ $ npm install --save-dev babel-preset-es2015
 To Include all Javascript versions:
 
 ```sh
-$ npm install --save-dev babel-preset-latest
+$ npm install --save-dev babel-preset-env
 ```
 
 ```js
 {
-  "presets": ["latest"]
+  "presets": ["env"]
 }
 ```
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -53,7 +53,7 @@ custom_js_with_timestamps:
 
 <!--lint disable no-shortcut-reference-link, no-undefined-references-->
 {% highlight shell %}
-npm install babel-preset-latest --save-dev
+npm install babel-preset-env --save-dev
 {% endhighlight %}
 <!--lint enable no-shortcut-reference-link, no-undefined-references-->
 
@@ -64,7 +64,7 @@ npm install babel-preset-latest --save-dev
 <!--lint disable no-shortcut-reference-link, no-undefined-references-->
 {% highlight json %}
 {
-  "presets": ["latest"]
+  "presets": ["env"]
 }
 {% endhighlight %}
 <!--lint enable no-shortcut-reference-link, no-undefined-references-->

--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@ npm install --save-dev babel-cli babel-preset-env
       <p>
         Babel has support for the latest version of JavaScript through syntax transformers.
         These <a href="https://babeljs.io/docs/plugins/">plugins</a> allow you to use new syntax, <strong>right now</strong> without waiting for browser support.
-        Check out our <a href="https://babeljs.io/docs/plugins/preset-env">env preset</a> to get started.
+        Check out our <a href="https://github.com/babel/babel-preset-env">env preset</a> to get started.
       </p>
 
       <p>You can install this preset with</p>

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@ third_party_js:
     <h3>Start by installing the Babel CLI and a preset</h3>
     <div class="lead text-left">
 {% highlight shell %}
-npm install --save-dev babel-cli babel-preset-latest
+npm install --save-dev babel-cli babel-preset-env
 {% endhighlight %}
     </div>
 
@@ -66,7 +66,7 @@ npm install --save-dev babel-cli babel-preset-latest
     <div class="lead text-left">
 {% highlight javascript %}
 {
-  "presets": ["latest"]
+  "presets": ["env"]
 }
 {% endhighlight %}
     </div>
@@ -81,14 +81,14 @@ npm install --save-dev babel-cli babel-preset-latest
       <p>
         Babel has support for the latest version of JavaScript through syntax transformers.
         These <a href="https://babeljs.io/docs/plugins/">plugins</a> allow you to use new syntax, <strong>right now</strong> without waiting for browser support.
-        Check out our <a href="https://babeljs.io/docs/plugins/preset-latest">latest preset</a> to get started.
+        Check out our <a href="https://babeljs.io/docs/plugins/preset-env">env preset</a> to get started.
       </p>
 
       <p>You can install this preset with</p>
 {% highlight shell %}
-npm install --save-dev babel-preset-latest
+npm install --save-dev babel-preset-env
 {% endhighlight %}
-      </p>and add <code>"latest"</code> to your <code>.babelrc</code> presets array.</p>
+      </p>and add <code>"env"</code> to your <code>.babelrc</code> presets array.</p>
     </div>
 
     <div class="col-md-6">


### PR DESCRIPTION
![screen shot 2016-12-13 at 11 30 01 am](https://cloud.githubusercontent.com/assets/588473/21148859/9b94e64a-c127-11e6-8b7c-d0cd281c9b97.png)

Has the same behavior as latest without options so might as well if we are going to recommend later.