### PR TITLE
babelrc.md: export env variables in example

### DIFF
--- a/docs/usage/babelrc.md
+++ b/docs/usage/babelrc.md
@@ -65,7 +65,7 @@ BABEL_ENV=production YOUR_COMMAND_HERE
 Or as a separate command:
 
 ```sh
-NODE_ENV=production
+export NODE_ENV=production
 ```
 ```sh
 YOUR_COMMAND_HERE


### PR DESCRIPTION
POSIX shells won't pass variables as environment variables unless they are explicitly exported, with the exception of the `$PATH` variable.