### PR TITLE
Use const instead of var in ES6+ example

### DIFF
--- a/_posts/2015-07-07-react-on-es6-plus.md
+++ b/_posts/2015-07-07-react-on-es6-plus.md
@@ -191,7 +191,7 @@ Often when composing components, we might want to pass down *most* of a parent c
 ```js
 class AutoloadingPostsGrid extends React.Component {
   render() {
-    var {
+    const {
       className,
       ...others,  // contains all properties of this.props except for className
     } = this.props;


### PR DESCRIPTION
`var`s are only supposed to be in ES5 examples, I think 😄 