### PR TITLE
Fix malformed <p> tag in index

### DIFF
--- a/index.md
+++ b/index.md
@@ -88,7 +88,7 @@ npm install --save-dev babel-cli babel-preset-env
 {% highlight shell %}
 npm install --save-dev babel-preset-env
 {% endhighlight %}
-      </p>and add <code>"env"</code> to your <code>.babelrc</code> presets array.</p>
+      <p>and add <code>"env"</code> to your <code>.babelrc</code> presets array.</p>
     </div>
 
     <div class="col-md-6">


### PR DESCRIPTION
I found a malformed <p> tag in the index page, on the "ES2015 and beyond" section. This is just a simple pull request to fix it :)