### PR TITLE
Fix 404 for babel-register menu item

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -25,7 +25,7 @@
         - title: babel-cli
           url: /docs/usage/cli/
         - title: babel-register
-          url: /docs/core-packages/babel-register/
+          url: /docs/core-packages/babel-register
 - title: Try it out
   url: /repl/
 - title: Blog


### PR DESCRIPTION
It appears that URLs are treated differently if they contain a trailing slash. `/docs/core-packages/babel-register` works, `/docs/core-packages/babel-register/` results in a 404.