### PR TITLE
Rename "Discourse" link to "Forum"

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -48,7 +48,7 @@
       </ul>
       <ul class="nav navbar-nav navbar-right">
         <li>
-          <a href="https://discuss.babeljs.io">Discourse</a>
+          <a href="https://discuss.babeljs.io">Forum</a>
         </li>
         <li>
           <a href="https://slack.babeljs.io/">Slack</a>


### PR DESCRIPTION
People that don't have experience with Discourse would be confused by the current link. People don't really care that Babel is using Discourse for the forum, just that it actually **is** a forum. Discourse is just an implementation detail, it could just as easily be SMF or phpBB or something else.

As examples from elsewhere in life, you'd say "send me an email" not "send me a Gmail", and "give me a phone call" not "contact me via the AT&T network", so this link should read "Forum" or "Discuss" rather than "Discourse".

@hzoo

