### PR TITLE
Make the REPL work when cookies are blocked.

### DIFF
--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -77,21 +77,24 @@
   /*
    * Long term storage for persistence of state/etc
    */
-  function StorageService () {}
-
-  StorageService.prototype.getStore = function () {
-    return window.localStorage;
+  function StorageService () {
+    try {
+      this.store = window.localStorage;
+    } catch (e) {
+      console.warn('Could not access localStorage. Disabling state persistence.');
+      this.store = null;
+    }
   }
 
   StorageService.prototype.get = function (key) {
     try {
-      return JSON.parse(this.getStore().getItem(key));
+      return JSON.parse(this.store.getItem(key));
     } catch(e) {}
   };
 
   StorageService.prototype.set = function (key, value) {
     try {
-      this.getStore().setItem(key, JSON.stringify(value));
+      this.store.setItem(key, JSON.stringify(value));
     } catch(e) {}
   };
 

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -77,19 +77,21 @@
   /*
    * Long term storage for persistence of state/etc
    */
-  function StorageService () {
-    this.store = window.localStorage;
+  function StorageService () {}
+
+  StorageService.prototype.getStore = function () {
+    return window.localStorage;
   }
 
   StorageService.prototype.get = function (key) {
     try {
-      return JSON.parse(this.store.getItem(key));
+      return JSON.parse(this.getStore().getItem(key));
     } catch(e) {}
   };
 
   StorageService.prototype.set = function (key, value) {
     try {
-      this.store.setItem(key, JSON.stringify(value));
+      this.getStore().setItem(key, JSON.stringify(value));
     } catch(e) {}
   };
 


### PR DESCRIPTION
If cookies are disabled, merely accessing `window.localStorage`
throws an error. So the REPL would fail to load when creating its
StorageService instance. This change moves the `localStorage`
property access inside the try-catch blocks, so the REPL can
still load even if `localStorage` is unavailable.

| Before | After |
|---|---|
| ![Before](http://i.imgur.com/WlnkbMr.png) | ![After](http://i.imgur.com/QLNJa4T.png) |