### PR TITLE
Trailing comma after object rest assignment in blog (React on ES6+)

### DIFF
--- a/_posts/2015-07-07-react-on-es6-plus.md
+++ b/_posts/2015-07-07-react-on-es6-plus.md
@@ -193,7 +193,7 @@ class AutoloadingPostsGrid extends React.Component {
   render() {
     const {
       className,
-      ...others,  // contains all properties of this.props except for className
+      ...others  // contains all properties of this.props except for className
     } = this.props;
     return (
       <div className={className}>


### PR DESCRIPTION
This creates syntax error and it's against current spec.