### PR TITLE
Recommend preset-env

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -26,15 +26,15 @@ Don't want to assemble your own set of plugins? No problem! Presets are sharable
 
 We've assembled some for common environments:
 
-> Each yearly preset only compiles what was ratified in that year. Use `preset-latest` to transform all yearly presets
+> Each yearly preset only compiles what was ratified in that year. Use `preset-env` to transform all yearly presets.
 
 - [env](/docs/plugins/preset-env/)
 - [es2015](/docs/plugins/preset-es2015/)
 - [es2016](/docs/plugins/preset-es2016/)
 - [es2017](/docs/plugins/preset-es2017/)
-- [flow](/docs/plugins/preset-flow/)
 - [latest](/docs/plugins/preset-latest/)
 - [react](/docs/plugins/preset-react/)
+- [flow](/docs/plugins/preset-flow/)
 
 > Many other community maintained presets are available [on npm](https://www.npmjs.com/search?q=babel-preset)!
 


### PR DESCRIPTION
Since preset-latest now has this install warning on npm:

> 💥  preset-latest accomplishes the same task as babel-preset-env. 🙏  Please install it with 'npm install babel-preset-env --save-dev'. '{ "presets": ["latest"] }' to '{ "presets": ["env"] }'. For more info, please check the docs: http://babeljs.io/docs/plugins/preset-env 👌. And let us know how you're liking Babel at @babeljs on 🐦

This switches to preset-env being recommended instead. I also moved preset-flow down to the bottom so preset-latest was next to the other yearly presets in the list.