### PR TITLE
Add debug option if env preset selected.

### DIFF
--- a/_sass/pages/_repl.scss
+++ b/_sass/pages/_repl.scss
@@ -88,7 +88,7 @@
   z-index: 4;
   bottom: 0;
   min-height: 30px;
-  max-height: 30%;
+  max-height: 50%;
   overflow: auto;
   width: 100%;
   padding: $padding-base-vertical $padding-base-horizontal;
@@ -182,7 +182,7 @@
   }
 }
 
-#option-builtIns-wrapper {
+#option-builtIns-wrapper, #option-debug-wrapper {
   padding-right: 15px;
 
   input[disabled] + span {

--- a/repl.html
+++ b/repl.html
@@ -9,7 +9,7 @@ custom_js_with_timestamps:
 third_party_js:
 - https://unpkg.com/babel-standalone@6/babel.min.js
 - https://unpkg.com/babel-polyfill@6/dist/polyfill.min.js
-- https://unpkg.com/babel-preset-env-standalone@0.0.3/babel-preset-env.min.js
+- https://unpkg.com/babel-preset-env-standalone@0.0.4/babel-preset-env.min.js
 - https://cdnjs.cloudflare.com/ajax/libs/ace/1.1.3/ace.js
 ---
 <div class="babel-repl">
@@ -48,6 +48,11 @@ third_party_js:
       <label for="option-builtIns" id="option-builtIns-wrapper" class="hidden">
         <input id="option-builtIns" type="checkbox">
         <span>Built-ins</span>
+      </label>
+
+      <label for="option-debug" id="option-debug-wrapper" class="hidden">
+        <input id="option-debug" type="checkbox">
+        <span>Debug</span>
       </label>
 
       <label for="option-lineWrap">

--- a/repl.html
+++ b/repl.html
@@ -9,7 +9,7 @@ custom_js_with_timestamps:
 third_party_js:
 - https://unpkg.com/babel-standalone@6/babel.min.js
 - https://unpkg.com/babel-polyfill@6/dist/polyfill.min.js
-- https://unpkg.com/babel-preset-env-standalone@0.0.4/babel-preset-env.min.js
+- https://unpkg.com/babel-preset-env-standalone@0.0.6/babel-preset-env.min.js
 - https://cdnjs.cloudflare.com/ajax/libs/ace/1.1.3/ace.js
 ---
 <div class="babel-repl">

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -205,17 +205,25 @@
     evt.stopPropagation();
   }
 
+  function envItemToString(item) {
+    return item.name + ' ' + JSON.stringify(item.targets);
+  }
+
   function onEnvBuild(node, opts, envResult) {
     let buffer = '';
     buffer += 'Using targets:\n'
     buffer += JSON.stringify(envResult.targets, null, 2);
     buffer += '\n\n';
     buffer += 'Using plugins:\n'
-    buffer += envResult.transformations.join('\n');
+    buffer += envResult.transformationsWithTargets
+      .map(envItemToString)
+      .join('\n');
     if (opts.useBuiltIns) {
       buffer += '\n\n';
       buffer += 'Using polyfills:\n';
-      buffer += envResult.polyfills.join('\n');
+      buffer += envResult.polyfillsWithTargets
+        .map(envItemToString)
+        .join('\n');
     }
     node.text(buffer);
   }

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 (function(babel, $, _, ace, window) {
   'use strict';
   var UPDATE_DELAY = 500;


### PR DESCRIPTION
With evaluate:

<img width="1440" alt="screen shot 2017-04-07 at 02 53 58" src="https://cloud.githubusercontent.com/assets/1521229/24780152/caf456e4-1b3d-11e7-994b-043e2d4767ef.png">

With huge output (scrollable):
<img width="1439" alt="screen shot 2017-04-07 at 02 53 29" src="https://cloud.githubusercontent.com/assets/1521229/24780156/cffb373e-1b3d-11e7-8a27-7b4e8c21957d.png">

`debug` option is appearing only when env preset was selected (like built-ins).