### PR TITLE
Add API usage page in menu

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -26,6 +26,8 @@
           url: /docs/usage/cli/
         - title: babel-register
           url: /docs/usage/babel-register/
+        - title: API
+          url: /docs/usage/api/
 - title: Try it out
   url: /repl/
 - title: Blog


### PR DESCRIPTION
Fixes #1228 

https://babeljs.io/docs/usage/api/ and https://babeljs.io/docs/core-packages/ are showing the same README.