### PR TITLE
update links for regenerator-runtime/runtime

### DIFF
--- a/docs/plugins/transform-regenerator.md
+++ b/docs/plugins/transform-regenerator.md
@@ -12,7 +12,7 @@ transform async and generator functions. `regeneratorRuntime` is not included.
 <blockquote class="babel-callout babel-callout-info">
   <h4>Runtime required</h4>
   <p>
-    You need to use either the <a href="/docs/usage/polyfill">Babel polyfill</a> or the <a href="https://github.com/facebook/regenerator/blob/master/runtime.js">regenerator runtime</a> so that <code>regeneratorRuntime</code> will be defined.
+    You need to use either the <a href="/docs/usage/polyfill">Babel polyfill</a> or the <a href="https://github.com/facebook/regenerator/blob/master/packages/regenerator-runtime/runtime.js">regenerator runtime</a> so that <code>regeneratorRuntime</code> will be defined.
   </p>
 </blockquote>
 

--- a/docs/usage/polyfill.md
+++ b/docs/usage/polyfill.md
@@ -8,7 +8,7 @@ package: babel-polyfill
 
 <p class="lead">
   Babel includes a polyfill that includes a custom
-  <a href="https://github.com/facebook/regenerator/blob/master/runtime.js">regenerator runtime</a>
+  <a href="https://github.com/facebook/regenerator/blob/master/packages/regenerator-runtime/runtime.js">regenerator runtime</a>
   and <a href="https://github.com/zloirock/core-js">core-js</a>.
 </p>
 


### PR DESCRIPTION
old link is being deprecated: https://github.com/facebook/regenerator/blob/master/runtime.js

closes https://github.com/babel/babel/issues/5692.