### PR TITLE
Jest usage update: Deprecated scriptPreprocessor fix

### DIFF
--- a/_includes/tools/jest/usage.md
+++ b/_includes/tools/jest/usage.md
@@ -6,9 +6,9 @@ In your `package.json` file make the following changes:
     "test": "jest"
   },
   "jest": {
-    "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
-    "testFileExtensions": ["es6", "js"],
-    "moduleFileExtensions": ["js", "json", "es6"]
+    "transform": {
+      "^.+\\.jsx?$": "babel-jest"
+    }
   }
 }
 ```


### PR DESCRIPTION
Replace deprecated scriptPreprocessor with transform config option.

```
 Deprecation Warning:

  Option "scriptPreprocessor" was replaced by "transform", which support multiple preprocessors.

  Jest now treats your current configuration as:
  {
    "transform": {".*": "<rootDir>/node_modules/babel-jest"}
  }

  Please update your configuration.

  Configuration Documentation:
  https://facebook.github.io/jest/docs/configuration.html
```