### PR TITLE
No more default to `development`

### DIFF
--- a/docs/usage/babelrc.md
+++ b/docs/usage/babelrc.md
@@ -50,7 +50,7 @@ You can use the `env` option to set specific options when in a certain environme
 Options specific to a certain environment are merged into and overwrite non-env specific options.
 
 The `env` key will be taken from `process.env.BABEL_ENV`, when this is not available then it uses
-`process.env.NODE_ENV` if even that is not available then it defaults to `"development"`.
+`process.env.NODE_ENV`.
 
 You can set this environment variable with the following:
 


### PR DESCRIPTION
Issue https://github.com/babel/babel/pull/4924 removed the default fallback