### PR TITLE
Update remark

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,21 +11,13 @@
     "test": "remark _posts docs _includes README.md --quiet"
   },
   "remarkConfig": {
-    "quiet": true,
-    "presets": [
-      "lint-recommended"
-    ],
     "plugins": {
-      "remark-lint": {
-        "list-item-bullet-indent": false,
-        "list-item-indent": "space",
-        "no-blockquote-without-caret": false,
-        "no-duplicate-headings-in-section": true,
-        "no-empty-url": true,
-        "no-literal-urls": false,
-        "no-shortcut-reference-link": false,
-        "no-undefined-references": false
-      }
+      "preset-lint-recommended": true,
+      "lint-list-item-indent": false,
+      "lint-no-blockquote-without-caret": false,
+      "lint-no-literal-urls": false,
+      "lint-no-duplicate-headings-in-section": true,
+      "lint-no-empty-url": true
     }
   },
   "author": "",
@@ -37,8 +29,12 @@
     "eslint-config-babel": "^6.0.0",
     "eslint-plugin-flowtype": "^2.30.0",
     "eslint-plugin-markdown": "^1.0.0-beta.3",
-    "remark-cli": "^2.1.0",
-    "remark-lint": "^5.2.0",
-    "remark-preset-lint-recommended": "^1.0.0"
+    "remark-cli": "^3.0.0",
+    "remark-lint-list-item-indent": "^1.0.0",
+    "remark-lint-no-blockquote-without-caret": "^1.0.0",
+    "remark-lint-no-duplicate-headings-in-section": "^1.0.0",
+    "remark-lint-no-empty-url": "^1.0.0",
+    "remark-lint-no-literal-urls": "^1.0.0",
+    "remark-preset-lint-recommended": "^2.0.0"
   }
 }


### PR DESCRIPTION
Hi folks! 👋

Thanks for using remark. I saw it was a bit outdated though and wanted to help you upgrade.

When upgrading, I found that three rules from [`remark-preset-lint-recommended`](https://github.com/wooorm/remark-lint/tree/master/packages/remark-preset-lint-recommended) were turned off, but when I left them turned on, they didn’t warn. Let me know if I should turn the following off again:

* [`list-item-bullet-indent`](https://github.com/wooorm/remark-lint/tree/master/packages/remark-lint-list-item-bullet-indent)
* [`no-shortcut-reference-link`](https://github.com/wooorm/remark-lint/tree/master/packages/remark-lint-no-shortcut-reference-link)
* [`no-undefined-references`](https://github.com/wooorm/remark-lint/tree/master/packages/remark-lint-no-undefined-references)

Let me know if you have questions.

Bye!
