### PR TITLE
Compress code in repl querystring with LZString

### DIFF
--- a/repl.html
+++ b/repl.html
@@ -11,6 +11,8 @@ third_party_js:
 - https://unpkg.com/babel-polyfill@6/dist/polyfill.min.js
 - https://unpkg.com/babel-preset-env-standalone@0.0.6/babel-preset-env.min.js
 - https://cdnjs.cloudflare.com/ajax/libs/ace/1.1.3/ace.js
+- https://cdnjs.cloudflare.com/ajax/libs/lz-string/1.4.4/base64-string.min.js
+- https://cdnjs.cloudflare.com/ajax/libs/lz-string/1.4.4/lz-string.min.js
 ---
 <div class="babel-repl">
   <form class="form babel-repl-toolbar">


### PR DESCRIPTION
This gives a reduction in url size of up to 60% while maintaining backwards compatibility (`code` will be accepted uncompressed, but the next-generated URL will use `code_lz`).

Some results:

|           | URL Before | URL After | Query Before | Query After | URL Comp. % | Query Comp. % |
|-----------|------------|-----------|--------------|-------------|-------------|---------------|
| [Example 1 (Kent Dodds ES6 workshop)](https://babeljs.io/repl/#?evaluate=true&lineWrap=false&presets=es2015%2Creact%2Cstage-2&experimental=true&loose=false&spec=false&playground=true&code=%2F%2F%20default%20parameters%0Afunction%20sum(x%2C%20y%20%3D%2012)%20%7B%0A%20%20%2F%2F%20y%20is%2012%20if%20not%20passed%20(or%20passed%20as%20undefined)%0A%20%20return%20x%20%2B%20y%0A%7D%0Aconsole.log(%0A%20%20'default%20params%3F'%2C%0A%20%20sum(3)%20%3D%3D%3D%2015%0A)%0A%0A%2F%2F%20rest%20...params%0Afunction%20multiplyRemainingArgLength(x%2C%20...y)%20%7B%0A%20%20%2F%2F%20y%20is%20an%20Array%0A%20%20return%20x%20*%20y.length%0A%7D%0Aconsole.log(%0A%20%20'rest%20params%3F'%2C%0A%20%20multiplyRemainingArgLength(3%2C%20%22hello%22%2C%20true)%20%3D%3D%3D%206%0A)%0A%0A%2F%2F%20stage-3%20proposal%3A%0A%2F%2F%20Trailing%20commas%20in%20function%20parameter%20lists%20and%20calls%0A%2F%2F%20https%3A%2F%2Fjeffmo.github.io%2Fes-trailing-function-commas%2F%0Atrail('a%20trailing%20comma'%2C%20'I%20can%20have')%0A%0Afunction%20trail(%0A%20%20arg1%2C%0A%20%20arg2%2C%20%2F%2F%20%3C--%20see!!%0A)%20%7B%0A%20%20console.log(%0A%20%20%20%20arg2%2C%0A%20%20%20%20arg1%2C%20%2F%2F%20%3C--%20see!!%0A%20%20)%0A%7D) | 1162B      | 776B      | 1011B        | 623B        | 33.2%       | 38.3%         |
| [Example 2](https://babeljs.io/repl/#?babili=false&evaluate=true&lineWrap=false&presets=es2015%2Creact%2Cstage-0&targets=&browsers=&builtIns=false&debug=false&code=class%20Foo%20extends%20React.Component%20%7B%0A%20%20render()%20%7B%0A%20%20%20%20return%20(%0A%20%20%20%20%20%20%3Cspan%3E%0A%20%20%20%20%20%20%20%20%7Bdo%20%7B%20if%20(foo%20%3D%3D%3D%20'bar')%20%7B%0A%20%20%20%20%20%20%20%20%20%20%3Ch3%3EYes!%3C%2Fh3%3E%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%3Ch3%3ENo!%3C%2Fh3%3E%0A%20%20%20%20%20%20%20%20%7D%7D%7D%0A%20%20%20%20%20%20%3C%2Fspan%3E%0A%20%20%20%20)%3B%0A%20%20%7D%0A%7D) | 615B       | 360B      | 462B         | 204B        | 46.3%       | 55.8%         |
