### PR TITLE
Switch links to preset-env from deprecated preset-latest

### DIFF
--- a/docs/plugins/preset-es2015.md
+++ b/docs/plugins/preset-es2015.md
@@ -6,7 +6,7 @@ permalink: /docs/plugins/preset-es2015/
 package: babel-preset-es2015
 ---
 
-> If you want to stay up to date, use the [latest preset](/docs/plugins/preset-latest/)
+> If you want to stay up to date, use the [env preset](/docs/plugins/preset-env/)
 
 This preset includes the following plugins:
 

--- a/docs/plugins/preset-es2016.md
+++ b/docs/plugins/preset-es2016.md
@@ -6,7 +6,7 @@ permalink: /docs/plugins/preset-es2016/
 package: babel-preset-es2016
 ---
 
-> If you want to stay up to date, use the [latest preset](/docs/plugins/preset-latest/)
+> If you want to stay up to date, use the [env preset](/docs/plugins/preset-env/)
 
 This preset includes the following plugins:
 

--- a/docs/plugins/preset-es2017.md
+++ b/docs/plugins/preset-es2017.md
@@ -6,7 +6,7 @@ permalink: /docs/plugins/preset-es2017/
 package: babel-preset-es2017
 ---
 
-> If you want to stay up to date, use the [latest preset](/docs/plugins/preset-latest/)
+> If you want to stay up to date, use the [env preset](/docs/plugins/preset-env/)
 
 This preset includes the following plugins:
 


### PR DESCRIPTION
The `preset-es*` pages still point to `preset-latest` in a banner at the top of the page, even though it has been deprecated. This PR changes that to `preset-env`. 