### PR TITLE
Sidebar to overflow when fixed

### DIFF
--- a/_sass/components/_sidebar.scss
+++ b/_sass/components/_sidebar.scss
@@ -81,6 +81,8 @@
     &.affix {
       position: fixed; /* Undo the static from mobile first approach */
       top: 70px;
+      bottom: 0;
+      overflow: auto;
     }
 
     &.affix-bottom {


### PR DESCRIPTION
## Bug:
The sidebar contains more items then can be displayed on some pages, the sidebar cannot be scrolled.

## What I did:
I've added a bottom-position and overflow:auto to the sidebar when it's fixed.

## How does this fix the problem:
The sidebar is now scrollable.

## Demo:
[![demo of the feature](http://img.youtube.com/vi/GvyDnd50I1U/0.jpg)](http://www.youtube.com/watch?v=GvyDnd50I1U "Demo of feature")