### PR TITLE
Use CDN in REPL

### DIFF
--- a/php.html
+++ b/php.html
@@ -8,7 +8,7 @@ custom_js_with_timestamps:
 - php.js
 third_party_js:
 - https://unpkg.com/babel-standalone@6/babel.min.js
-- https://packd.now.sh/babel-preset-php@1.0.0
+- https://bundle.run/babel-preset-php@1.0.0
 - https://unpkg.com/babel-polyfill@6/dist/polyfill.min.js
 - https://cdnjs.cloudflare.com/ajax/libs/ace/1.1.3/ace.js
 - https://cdnjs.cloudflare.com/ajax/libs/lz-string/1.4.4/base64-string.min.js


### PR DESCRIPTION
See https://github.com/Rich-Harris/packd/issues/10

I didn't change the 7 REPL since https://github.com/babel/babel.github.io/pull/1280 will remove the dependencies from `packd.now.sh` .