### PR TITLE
Remove redirect_from in REPL

### DIFF
--- a/repl.html
+++ b/repl.html
@@ -2,7 +2,6 @@
 layout: default
 permalink: /repl/
 fullscreen: true
-redirect_from: "/repl.html"
 custom_js_with_timestamps:
 - pretty-format.js
 - repl.js


### PR DESCRIPTION
I think this is breaking the REPL on Netlify. If we do want to redirect people hitting `/repl.html`, we can configure a Netlify redirect in `_redirects` for that (which is a true server-side redirect).