### PR TITLE
Update dead link

### DIFF
--- a/docs/preset-stage-0.md
+++ b/docs/preset-stage-0.md
@@ -7,7 +7,7 @@ sidebar_label: stage-0
 > As of Babel v7, all the stage presets have been deprecated.
 > Check [the blog post](/blog/2018/07/27/removing-babels-stage-presets) for more information.
 >
-> For upgrade instructions, see [the README](https://github.com/babel/babel/blob/master/packages/babel-preset-stage-0/README.md).
+> For upgrade instructions, see [the README](https://github.com/babel/babel/blob/755ec192e22c6b6e00782e4810366d0166fdbebd/packages/babel-preset-stage-0/README.md).
 
 ## Install
 


### PR DESCRIPTION
This seems to be where it was originally pointing. 
Alternatively, I could see pointing to [this page](https://babeljs.io/docs/en/next/v7-migration)