### PR TITLE
fix: REPL shows the wrong "Current Plugin"

### DIFF
--- a/js/repl/Transitions.js
+++ b/js/repl/Transitions.js
@@ -40,7 +40,7 @@ export default class Transitions {
     callback: any
   ) => {
     return (...args: any) => {
-      const currentNode = args[0].node.type
+      const currentNode = args[0].node.type;
 
       callback.call(this, ...args);
 


### PR DESCRIPTION
Move `callback.call(this, ...args)` ahead of `generate`

closes #2581

After this fix, the [REPL](https://deploy-preview-2582--babel.netlify.app/repl#?browsers=defaults&build=&builtIns=false&corejs=3.6&spec=false&loose=false&code_lz=GYVwdgxgLglg9mABMOcAUBKRBvAUIxGYRNRKAJxAFNEs8CDyqoRyx9EBfXDiBAZyhkYAWyrlEAXkT9mASTBRxANwCGAGzQcCmKQD4ciPmH5x1VAHTq4Ac1KwxErJwA02xAEYADD44ZcnEA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=true&fileSize=true&timeTravel=true&sourceType=unambiguous&lineWrap=true&presets=env%2Creact%2Cstage-0%2Cstage-1%2Cstage-2%2Cstage-3&prettier=false&targets=&version=7.15.8&externalPlugins=babel-plugin-minify-dead-code-elimination%400.5.1&assumptions=%7B%7D) shows the correct "Current Plugin"