### PR TITLE
Fix `annexB` option name

### DIFF
--- a/docs/parser.md
+++ b/docs/parser.md
@@ -35,7 +35,7 @@ mind. When in doubt, use `.parse()`.
 | Version   | Changes                                            |
 | --------- | -------------------------------------------------- |
 | `v7.23.0` | Added `createImportExpressions`                    |
-| `v7.21.0` | Added `allowNewTargetOutsideFunction` and `annexb` |
+| `v7.21.0` | Added `allowNewTargetOutsideFunction` and `annexB` |
 | `v7.16.0` | Added `startColumn`                                |
 | `v7.15.0` | Added `attachComment`                              |
 | `v7.7.0`  | Added `errorRecovery`                              |
@@ -75,7 +75,7 @@ mind. When in doubt, use `.parse()`.
 
 - **attachComment**: By default, Babel attaches comments to adjacent AST nodes. When this option is set to `false`, comments are not attached. It can provide up to 30% performance improvement when the input code has _many_ comments. `@babel/eslint-parser` will set it for you. It is not recommended to use `attachComment: false` with Babel transform, as doing so removes all the comments in output code, and renders annotations such as `/* istanbul ignore next */` nonfunctional.
 
-- **annexb**: By default, Babel parses JavaScript according to [ECMAScript's Annex B "_Additional ECMAScript Features for Web Browsers_"](https://tc39.es/ecma262/#sec-additional-ecmascript-features-for-web-browsers) syntax. When this option is set to `false`, Babel will parse syntax without the extensions specific to Annex B.
+- **annexB**: By default, Babel parses JavaScript according to [ECMAScript's Annex B "_Additional ECMAScript Features for Web Browsers_"](https://tc39.es/ecma262/#sec-additional-ecmascript-features-for-web-browsers) syntax. When this option is set to `false`, Babel will parse syntax without the extensions specific to Annex B.
 
 - **createImportExpressions**: By default, the parser parses dynamic import `import()` as call expression nodes. When this option is set to `true`, `ImportExpression` AST nodes are created instead. This option will default to `true` in Babel 8.
 


### PR DESCRIPTION
The correct option name should be `annexB`: 

https://github.com/babel/babel/blob/51e9e0c6407d643dbc8f1344d76d54aa6543b132/packages/babel-parser/typings/babel-parser.source.d.ts#L57-L61