### PR TITLE
docs: add ERM transform to preset-env

### DIFF
--- a/docs/plugin-transform-explicit-resource-management.md
+++ b/docs/plugin-transform-explicit-resource-management.md
@@ -4,6 +4,10 @@ title: "@babel/plugin-transform-explicit-resource-management"
 sidebar_label: explicit-resource-management
 ---
 
+:::info
+This plugin is included in `@babel/preset-env`, in [ES2026](https://github.com/tc39/proposals/blob/master/finished-proposals.md).
+:::
+
 This plugin enables Babel to transform using declarations `using handler = await read();`.
 
 ## Example

--- a/docs/plugins-list.md
+++ b/docs/plugins-list.md
@@ -24,6 +24,10 @@ sidebar_label: Plugins List
 - [throw-expressions](plugin-proposal-throw-expressions.md)
 - [record-and-tuple](plugin-proposal-record-and-tuple.md)
 
+### ES2026
+
+- [explicit-resource-management](./plugin-transform-explicit-resource-management.md)
+
 ### ES2025
 
 - [duplicate-named-capturing-groups-regex](plugin-transform-duplicate-named-capturing-groups-regex.md)


### PR DESCRIPTION
### Documentation Updates:

* [`docs/plugin-transform-explicit-resource-management.md`](diffhunk://#diff-a613d6e1266ca05574496b4a7ee81e24342c19ee84d4df031a56e4312a130f7aR7-R10): Added an informational note specifying that the plugin is included in `@babel/preset-env` as part of ES2026.
* [`docs/plugins-list.md`](diffhunk://#diff-10256b519eb3618819dd1d4a39da3a80e693135560f94bf4743fed7127c11f3cR27-R30): Added a new section for ES2026 and listed the `explicit-resource-management` plugin under it.