### PR TITLE
docs: LVal coverage update

### DIFF
--- a/docs/v8-migration-api.md
+++ b/docs/v8-migration-api.md
@@ -1019,6 +1019,22 @@ Most of the changes to our TypeScript-specific AST nodes are to reduce the diffe
   }
   ```
 
+- Remove `AssignmentPattern` and `RestElement` from the `LVal` alias ([#17387](https://github.com/babel/babel/pull/17387))
+
+  An `LVal` node represents valid nodes as the left hand side (LHS) of an assignment expression. As `AssignmentPattern` and `RestElement` can not be the LHS, `t.isLVal(t.assignmentPattern(...))` and `t.isLVal(t.restElement(...))` will return `false` in Babel 8.
+
+    __Migration__: Search usage of the `t.isLVal` and `t.assertsLVal` functions, and of the `t.LVal` type alias: if they need to also accept `AssignmentPattern` or `RestElement` nodes, you can broaden `t.LVal` with `t.PatternLike`:
+
+  ```diff title="my-babel-plugin.js"
+  // Iterate rest element within an object pattern
+  for (const propertyPath of path.get("properties")) {
+  - if (t.isLVal(propertyPath.node)) {
+  + if (t.isLVal(propertyPath.node) || t.isPatternLike(propertyPath.node)) {
+      doSomethingWith(propertyPath);
+    }
+  }
+  ```
+
 - Require an `Identifier` node as the third argument of `t.tsTypeParameter` ([#12829](https://github.com/babel/babel/pull/12829))
 
   This is due to the corresponding [AST shape change](#ast-TSTypeParameter).


### PR DESCRIPTION
Docs PR for https://github.com/babel/babel/pull/17387

### Documentation updates for Babel 8 AST changes:

* **Removed `AssignmentPattern` and `RestElement` from `LVal` alias**: The `LVal` node no longer includes `AssignmentPattern` and `RestElement`, as these cannot be the left-hand side (LHS) of an assignment expression. Consequently, `t.isLVal` and `t.assertsLVal` will return `false` for these nodes. The migration guide suggests broadening the `t.LVal` type to include `t.PatternLike` where necessary.