### PR TITLE
docs: fix ConfigAPI docs

### DIFF
--- a/docs/config-files.md
+++ b/docs/config-files.md
@@ -308,7 +308,7 @@ along with the original repo root.
 
 JS config files may export a function that will be passed config API:
 
-````babel7
+:::babel7
 
 ```js title="babel.config.js"
 module.exports = function(api) {
@@ -316,9 +316,9 @@ module.exports = function(api) {
 };
 ```
 
-````
+:::
 
-````babel8
+:::babel8
 
 ```js title="babel.config.js"
 /**
@@ -330,7 +330,7 @@ module.exports = function(api) {
 };
 ```
 
-````
+:::
 
 The ConfigAPI object `api` provides the following properties or methods:
 


### PR DESCRIPTION
Unlike `PluginAPI` and `PresetAPI`, the `ConfigAPI` injected to the Babel config does not contain exports from `@babel/core`.

Spot this issue when reading the `@types/babel__core` source: 

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f3c4306d7f3b710b4087d2c1c0eb3a19973b516e/types/babel__core/index.d.ts#L706