### PR TITLE
Mention drop of ESLint7/8 support in migration docs

### DIFF
--- a/docs/v8-migration.md
+++ b/docs/v8-migration.md
@@ -693,6 +693,10 @@ Make sure to also check the [@babel/plugin-transform-flow-strip-types](#babel-pl
 
 ![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
 
+- Drop support for ESLint 7 and ESLint 8 ([#17763](https://github.com/babel/babel/pull/17763))
+
+  **Migration**: Upgrade your ESLint to version 9 or above.
+
 - Remove `allowImportExportEverywhere` option ([#13921](https://github.com/babel/babel/pull/13921))
 
   **Migration**: Use `babelOptions.parserOpts.allowImportExportEverywhere` instead.


### PR DESCRIPTION
Docs for https://github.com/babel/babel/pull/17763

We apparently do not mention which ESLint version we support in the docs, only in the peerDeps.