### PR TITLE
docs: add v8 migration entries for inclusive terminology renames

### DIFF
--- a/docs/v8-migration-api.md
+++ b/docs/v8-migration-api.md
@@ -1319,6 +1319,19 @@ Other than the changes listed below, `@babel/parser` is affected by all the [AST
 
   **Migration**: Use `node.shorthand` rather than `node.extra.shorthand`.
 
+### `@babel/template`
+
+![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
+
+- Rename `placeholderWhitelist` option to `placeholderAllowlist` ([#17830](https://github.com/babel/babel/pull/17830))
+
+  __Migration__: Replace `placeholderWhitelist` with `placeholderAllowlist`. To support both Babel 7 and Babel 8, you can pass both options simultaneously -- the new name will take precedence.
+
+  ```diff
+  - template(code, { placeholderWhitelist: new Set(["FOO"]) })
+  + template(code, { placeholderAllowlist: new Set(["FOO"]) })
+  ```
+
 ### `@babel/traverse`
 
 ![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
@@ -1424,6 +1437,16 @@ Other than the changes listed below, `@babel/parser` is affected by all the [AST
   ```
 
   These methods are meant to be private so there is no real migration approach. If your plugin / build is broken by this change, feel free to open an issue and tell us how you use these methods and we can see what we can do after Babel 8 is released.
+
+
+- Rename `blacklist` visitor option to `denylist` ([#17830](https://github.com/babel/babel/pull/17830))
+
+  __Migration__: Replace `blacklist` with `denylist` in your visitor options. To support both Babel 7 and Babel 8, you can pass both options simultaneously -- `denylist` will take precedence.
+
+  ```diff
+  - traverse(ast, { blacklist: ["MemberExpression"], enter() {} })
+  + traverse(ast, { denylist: ["MemberExpression"], enter() {} })
+  ```
 
 ### `@babel/eslint-plugin`
 

--- a/docs/v8-migration.md
+++ b/docs/v8-migration.md
@@ -741,6 +741,19 @@ Make sure to also check the [@babel/plugin-transform-flow-strip-types](#babel-pl
 
   **Migration**: Upgrade your ESLint to version 9 or above.
 
+### `@babel/plugin-external-helpers` {#babel-plugin-external-helpers}
+
+![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
+
+- Rename `whitelist` option to `allowlist` ([#17830](https://github.com/babel/babel/pull/17830))
+
+  **Migration**: Replace `whitelist` with `allowlist` in your configuration. To support both Babel 7 and Babel 8, you can pass both options simultaneously -- the new name will take precedence.
+
+  ```diff
+  - ["external-helpers", { "whitelist": ["createClass"] }]
+  + ["external-helpers", { "allowlist": ["createClass"] }]
+  ```
+
 ### `@babel/eslint-parser` {#babel-eslint-parser}
 
 ![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)


### PR DESCRIPTION
## Summary

Documents the option renames introduced in [babel/babel#17830](https://github.com/babel/babel/pull/17830):

- **`@babel/plugin-external-helpers`**: `whitelist` option renamed to `allowlist` (in `v8-migration.md`)
- **`@babel/template`**: `placeholderWhitelist` option renamed to `placeholderAllowlist` (in `v8-migration-api.md`)
- **`@babel/traverse`**: `blacklist` visitor option renamed to `denylist` (in `v8-migration-api.md`)

All entries document the cross-version compatibility path (passing both old and new option names simultaneously).

Requested by @nicolo-ribaudo in https://github.com/babel/babel/pull/17830#pullrequestreview-2675816553.