### PR TITLE
docs: add docusaurus-plugin-copy-page-button

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@mdx-js/react": "^3.1.1",
     "@types/node": "^24.0.4",
     "@types/react": "^19.2.14",
+    "docusaurus-plugin-copy-page-button": "^0.4.2",
     "eslint": "^9.35.0",
     "eslint-formatter-codeframe": "^7.32.1",
     "eslint-plugin-react": "^7.37.5",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@mdx-js/react": "^3.1.1",
     "@types/node": "^24.0.4",
     "@types/react": "^19.2.14",
-    "docusaurus-plugin-copy-page-button": "^0.4.2",
+    "docusaurus-plugin-copy-page-button": "^0.4.3",
     "eslint": "^9.35.0",
     "eslint-formatter-codeframe": "^7.32.1",
     "eslint-plugin-react": "^7.37.5",

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -168,7 +168,7 @@ const siteConfig: Config = {
       onBrokenMarkdownLinks: "throw",
     }
   },
-  plugins: [docusaurusReplRoutePlugin, require("./webpack.plugin.js")],
+  plugins: [docusaurusReplRoutePlugin, require("./webpack.plugin.js"), "docusaurus-plugin-copy-page-button"],
   presets: [
     [
       "@docusaurus/preset-classic",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5452,6 +5452,7 @@ __metadata:
     algoliasearch: "npm:^5.49.0"
     clsx: "npm:^2.1.1"
     core-js: "npm:^3.43.0"
+    docusaurus-plugin-copy-page-button: "npm:^0.4.2"
     eslint: "npm:^9.35.0"
     eslint-formatter-codeframe: "npm:^7.32.1"
     eslint-plugin-react: "npm:^7.37.5"
@@ -6908,6 +6909,16 @@ __metadata:
   dependencies:
     esutils: "npm:^2.0.2"
   checksum: 10/555684f77e791b17173ea86e2eea45ef26c22219cb64670669c4f4bebd26dbc95cd90ec1f4159e9349a6bb9eb892ce4dde8cd0139e77bedd8bf4518238618474
+  languageName: node
+  linkType: hard
+
+"docusaurus-plugin-copy-page-button@npm:^0.4.2":
+  version: 0.4.2
+  resolution: "docusaurus-plugin-copy-page-button@npm:0.4.2"
+  peerDependencies:
+    "@docusaurus/core": ^3.0.0
+    react: ^18.0.0 || ^19.0.0
+  checksum: 10/e591ff132932e4e2ba028f8b221309a6146d618c005c3fd985e3dffe6f435468d6b88d3ac91f717e46762524451ffc8cef75e1fd6de7ea4692488a3123ebc08b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5452,7 +5452,7 @@ __metadata:
     algoliasearch: "npm:^5.49.0"
     clsx: "npm:^2.1.1"
     core-js: "npm:^3.43.0"
-    docusaurus-plugin-copy-page-button: "npm:^0.4.2"
+    docusaurus-plugin-copy-page-button: "npm:^0.4.3"
     eslint: "npm:^9.35.0"
     eslint-formatter-codeframe: "npm:^7.32.1"
     eslint-plugin-react: "npm:^7.37.5"
@@ -6912,13 +6912,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"docusaurus-plugin-copy-page-button@npm:^0.4.2":
-  version: 0.4.2
-  resolution: "docusaurus-plugin-copy-page-button@npm:0.4.2"
+"docusaurus-plugin-copy-page-button@npm:^0.4.3":
+  version: 0.4.3
+  resolution: "docusaurus-plugin-copy-page-button@npm:0.4.3"
   peerDependencies:
     "@docusaurus/core": ^3.0.0
     react: ^18.0.0 || ^19.0.0
-  checksum: 10/e591ff132932e4e2ba028f8b221309a6146d618c005c3fd985e3dffe6f435468d6b88d3ac91f717e46762524451ffc8cef75e1fd6de7ea4692488a3123ebc08b
+  checksum: 10/4b87e5e0fd4cc4b11643e7799c60e976dfbee13c223b50f739ba1ee58037c13c57df762edcdbe2227ea3aa66ce893a78158d09fcc4681aa5571c88ff1201c79c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What this adds

A "Copy page" button in the docs sidebar that exports the current Babel docs page as clean markdown, with one-click "Open in ChatGPT", "Open in Claude", and "Open in Gemini" actions.

## Why for Babel

Babel docs are exactly the kind of pages devs paste into LLMs — plugin reference, preset options, config troubleshooting, version migration notes. A one-click "page → markdown → Open in Claude/ChatGPT" handoff turns that flow from a multi-step copy-paste into a single button.

The plugin is currently shipping on Ethereum execution-apis, Sui (Mysten Labs), Walrus, Seal, SuiNS, Monad, Flare, Kaia, Nillion, Chronicle, and Cardano docs. It's also listed in the [official Docusaurus community plugins](https://docusaurus.io/community/resources#plugins).

## Changes

- Adds `docusaurus-plugin-copy-page-button` to `devDependencies` in root `package.json` (^0.4.2, alphabetical), matching the existing Docusaurus dep convention here
- Appends the plugin string to the `plugins` array in `website/docusaurus.config.ts`

The button auto-injects into the table-of-contents sidebar. No further config required, theme-aware, mobile-friendly, ~5kb client.

## Links

- Live demo: https://portdeveloper.github.io/copy-page-button-showcase/
- Plugin repo: https://github.com/portdeveloper/docusaurus-plugin-copy-page-button
- npm: https://www.npmjs.com/package/docusaurus-plugin-copy-page-button

Happy to revert or adjust if this doesn't fit the project's direction.