### PR TITLE
docs(plugin-transform-runtime): add Node.js application usage example

### DIFF
--- a/docs/plugin-transform-runtime.md
+++ b/docs/plugin-transform-runtime.md
@@ -96,6 +96,49 @@ require("@babel/core").transformSync("code", {
 });
 ```
 
+### In a Node.js application
+
+When building a Node.js application (not just transforming files), you can integrate `@babel/plugin-transform-runtime` with [`@babel/register`](register.md) so that helpers are shared at runtime:
+
+**1. Install the required packages:**
+
+```shell npm2yarn
+npm install --save-dev @babel/core @babel/register @babel/plugin-transform-runtime
+npm install --save @babel/runtime
+```
+
+**2. Create a Babel config file:**
+
+```json title="babel.config.json"
+{
+  "plugins": ["@babel/plugin-transform-runtime"]
+}
+```
+
+**3. Create an entry file that hooks into Node's `require`:**
+
+```js title="register.js"
+require("@babel/register")({
+  // Only transpile files in src/, not node_modules
+  ignore: [/node_modules/],
+});
+
+// Now require your app entry point — it will be transpiled on the fly
+require("./src/index");
+```
+
+**4. Run your app:**
+
+```shell title="Shell"
+node register.js
+```
+
+With this setup, all `require()`d files under `src/` will be compiled by Babel. Shared helpers from `@babel/runtime` are `require()`d once and reused across all compiled files, avoiding inline helper duplication.
+
+:::tip
+For production use, consider pre-compiling your source with the Babel CLI (`babel src --out-dir dist`) so helpers are resolved at build time rather than at Node startup.
+:::
+
 ## Options
 
 


### PR DESCRIPTION
## Summary

Closes babel/babel#7357

Adds a concrete, step-by-step code example showing how to use `@babel/plugin-transform-runtime` in a Node.js application using `@babel/register`.

The existing docs cover config file, CLI, and bare Node API usage — but there was no example showing the common real-world pattern of using `@babel/register` with the plugin in a running Node app.

## What was added

A new **"In a Node.js application"** subsection under the **Usage → Via Node API** heading, covering:

1. Installing all required packages (`@babel/register`, `@babel/runtime`, etc.)
2. Creating `babel.config.json` with the plugin
3. Creating a `register.js` entry point that hooks into Node's `require`
4. Running the app with `node register.js`

Also includes a tip about pre-compiling for production use.

## Motivation

This was a long-standing gap in the docs ([babel/babel#7357](https://github.com/babel/babel/issues/7357), opened 2018). Developers integrating Babel into Node.js apps repeatedly hit this use case and couldn't find a concrete example in the official docs.