### PR TITLE
Add Node.js 22 to supported versions of Babel 8.0.0

### DIFF
--- a/website/blog/2026-06-16-8.0.0.md
+++ b/website/blog/2026-06-16-8.0.0.md
@@ -33,9 +33,9 @@ Before getting on with the changelog, we want to tell you one more thing. We, th
 
 ### Babel 8 is ESM-only
 
-Babel now ships as ESM, and requires Node.js 24, 26, or newer.
+Babel now ships as ESM, and requires Node.js 22, 24, 26, or newer.
 
-Node.js 22 and 25 reached end-of-life earlier this year, and will not receive any more security fixes: if you are using any of those versions, or even older ones, we strongly recommend you upgrade to a supported version of Node.js.
+Node.js 20 and 25 reached end-of-life earlier this year, and will not receive any more security fixes: if you are using any of those versions, or even older ones, we strongly recommend you upgrade to a supported version of Node.js.
 
 ### Stop compiling to ES5 by default
 


### PR DESCRIPTION
The blog post stated that Babel 8.0.0 supports Node.js 24 or greater. But based on the changelog, it looks like Node.js 22 is also supported. This aligns with the fact that Node.js 20 reached EOL this year, not Node.js 22.