### PR TITLE
Note removal of `useBuiltIns`

### DIFF
--- a/docs/features-timeline.md
+++ b/docs/features-timeline.md
@@ -533,7 +533,7 @@ This has a lot more changes since it was 2 years of pre-releases.
 - Remove yearly presets (`@babel/preset-es2015`) and Stage presets (`@babel/preset-stage-0`) ([blog post](https://babeljs.io/blog/2018/07/27/removing-babels-stage-presets)).
 - Added "pure" (`/*#__PURE__*/` ) annotation support in certain cases. (Implemented later as [@babel/helper-annotate-as-pure](helper-annotate-as-pure.md)
 - Add project-wide `babel.config.js` config file ([docs](config-files.md)) and [`overrides`](options.md#overrides) config option.
-- Added `"useBuiltIns: "usage"` to [`@babel/preset-env`](preset-env.md#usebuiltins)
+- Added `"useBuiltIns: "usage"` to [`@babel/preset-env`](preset-env.md#usebuiltins-corejs)
 - Support TypeScript via `@babel/preset-typescript`
 - Support JSX Fragments `<></>`
 - Support a ton of TC39 proposals:

--- a/docs/options.md
+++ b/docs/options.md
@@ -684,7 +684,7 @@ For instance, [`@babel/plugin-transform-runtime`](plugin-transform-runtime.md)
 relies on the type of the current document to decide whether to insert
 an `import` declaration, or a `require()` call.
 [`@babel/preset-env`](preset-env.md) also does the same for its
-[`"useBuiltIns"`](preset-env.md#usebuiltins) option. Since Babel defaults to treating files
+[`"useBuiltIns"`](preset-env.md#usebuiltins-corejs) option. Since Babel defaults to treating files
 are ES modules, generally these plugins/presets will insert `import` statements. Setting
 the correct `sourceType` can be important because having the wrong type can lead to cases
 where Babel would insert `import` statements into files that are meant to be CommonJS

--- a/docs/plugin-transform-runtime.md
+++ b/docs/plugin-transform-runtime.md
@@ -121,6 +121,8 @@ You can read more about configuring plugin options [here](./plugins.md#plugin-op
 
 ### `corejs`
 
+:::babel7
+
 `false`, `2`, `3` or `{ version: 2 | 3, proposals: boolean }`, defaults to `false`.
 
 e.g. `['@babel/plugin-transform-runtime', { corejs: 3 }],`
@@ -147,11 +149,17 @@ This option requires changing the dependency used to provide the necessary runti
 | `2`             | `npm install --save @babel/runtime-corejs2` |
 | `3`             | `npm install --save @babel/runtime-corejs3` |
 
-:::caution
+:::babel7
 
-The `corejs` option will be removed in Babel 8. To inject polyfills, you can use [`babel-plugin-polyfill-corejs3`](https://github.com/babel/babel-polyfills/blob/main/packages/babel-plugin-polyfill-corejs3/README.md) or [`babel-plugin-polyfill-corejs2`](https://github.com/babel/babel-polyfills/blob/main/packages/babel-plugin-polyfill-corejs2/README.md) directly.
+::::babel8
+
+:::danger
+
+This option has been removed in Babel 8. To inject polyfills, you can use [`babel-plugin-polyfill-corejs3`](https://github.com/babel/babel-polyfills/blob/main/packages/babel-plugin-polyfill-corejs3/README.md) directly.
 
 :::
+
+::::
 
 ### `helpers`
 

--- a/docs/plugin-transform-runtime.md
+++ b/docs/plugin-transform-runtime.md
@@ -427,9 +427,9 @@ without worrying about where they come from.
 
 **NOTE:** Instance methods such as `"foobar".includes("foo")` will only work when using `corejs: 3`.
 
-### Helper aliasing
-
 ::::
+
+### Helper aliasing
 
 Usually Babel will place helpers at the top of your file to do common tasks to avoid
 duplicating the code around in the current file. Sometimes these helpers can get a

--- a/docs/polyfill.md
+++ b/docs/polyfill.md
@@ -32,7 +32,7 @@ Because this is a polyfill (which will run before your source code), we need it 
 
 ## Size
 
-The polyfill is provided as a convenience but you should use it with [`@babel/preset-env`](preset-env.md) and the [`useBuiltIns` option](preset-env.md#usebuiltins) so that it doesn't include the whole polyfill which isn't always needed. Otherwise, we would recommend you import the individual polyfills manually.
+The polyfill is provided as a convenience but you should use it with [`@babel/preset-env`](preset-env.md) and the [`useBuiltIns` option](preset-env.md#usebuiltins-corejs) so that it doesn't include the whole polyfill which isn't always needed. Otherwise, we would recommend you import the individual polyfills manually.
 
 ## TC39 Proposals
 

--- a/docs/preset-env.md
+++ b/docs/preset-env.md
@@ -227,15 +227,15 @@ The possible options are the same as the `include` option.
 
 This option is useful for excluding a transform like `@babel/plugin-transform-regenerator`, for example if you are using another plugin like [fast-async](https://github.com/MatAtBread/fast-async) instead of [Babel's async-to-gen](plugin-transform-async-generator-functions.md).
 
-### `useBuiltIns`
+### `useBuiltIns`, `corejs`
+
+:::babel7
 
 `"usage"` | `"entry"` | `false`, defaults to `false`.
 
 This option configures how `@babel/preset-env` handles polyfills.
 
 When either the `usage` or `entry` options are used, `@babel/preset-env` will add direct references to `core-js` modules as bare imports (or requires). This means `core-js` will be resolved relative to the file itself and needs to be accessible.
-
-:::babel7
 
 Since `@babel/polyfill` was deprecated in 7.4.0, we recommend directly adding `core-js` and setting the version via the [`corejs`](#corejs) option.
 
@@ -249,15 +249,15 @@ npm install core-js@2 --save
 
 :::
 
-:::babel8
+::::babel8
 
-When auto-injecting polyfills using `@babel/preset-env`, you must add `core-js` to your dependencies:
+:::danger
 
-```shell npm2yarn
-npm install core-js
-```
+This option has been removed in Babel 8. To inject polyfills, you can use [`babel-plugin-polyfill-corejs3`](https://github.com/babel/babel-polyfills/blob/main/packages/babel-plugin-polyfill-corejs3/README.md) directly.
 
 :::
+
+::::
 
 #### `useBuiltIns: 'entry'`
 

--- a/docs/v8-migration.md
+++ b/docs/v8-migration.md
@@ -25,7 +25,7 @@ You should read this full document to understand what options you need to change
 - If you use `@babel/preset-react` or `@babel/plugin-transform-react-jsx`, explicitly set their [`runtime`](./preset-react.md#runtime) option (Babel 7 defaults to `"classic"`, Babel 8 to `"automatic"`). If you keep using the classic runtime, set the `useSpread` option to `true`.
 - If you use the TypeScript or Flow presets, replace the `isTSX` and `allExtensions` options with [`ignoreExtensions`](#babel-preset-typescript).
 - If you are transforming TypeScript or Flow, set the `allowDeclareFields` option to `true` (see [TypeScript](./preset-typescript.md#allowdeclarefields)).
-- If you use `@babel/plugin-transform-runtime`'s `corejs` or [`@babel/preset-env`'s `useBuiltIns`](./preset-env.md#usebuiltins) options, remove them and use [`babel-plugin-polyfill-corejs3`](https://github.com/babel/babel-polyfills/tree/main/packages/babel-plugin-polyfill-corejs3) instead.
+- If you use `@babel/plugin-transform-runtime`'s `corejs` or [`@babel/preset-env`'s `useBuiltIns`](./preset-env.md#usebuiltins-corejs) options, remove them and use [`babel-plugin-polyfill-corejs3`](https://github.com/babel/babel-polyfills/tree/main/packages/babel-plugin-polyfill-corejs3) instead.
 - If you use `@babel/plugin-proposal-decorators`, set its [`version`](./plugin-proposal-decorators.md#version) option to `legacy` or `2023-11`.
 - Remove the `@babel/plugin-proposal-record-and-tuple` and `@babel/plugin-syntax-import-assertions` plugins if you are using them.
 


### PR DESCRIPTION
Docs for https://github.com/babel/babel/pull/18079. This is already mentioned in the migration guide and Babel 8 blog post.